### PR TITLE
fix: Merge both compile classpath and runtime classpath 

### DIFF
--- a/server/src/test/java/com/microsoft/java/bs/core/contrib/gradle/GradleBuildTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/contrib/gradle/GradleBuildTest.java
@@ -54,7 +54,7 @@ class GradleBuildTest {
     for (JavaBuildTarget javaBuildTarget : javaBuildTargets) {
       assertEquals(1, javaBuildTarget.getSourceDirs().size());
       if (Objects.equals(javaBuildTarget.getSourceSetName(), "test")) {
-        assertEquals(6, javaBuildTarget.getModuleDependencies().size());
+        assertEquals(8, javaBuildTarget.getModuleDependencies().size());
         assertEquals(0, javaBuildTarget.getProjectDependencies().size());
       }
     }


### PR DESCRIPTION
- This is to make sure that the classpath is complete for the language server to work properly, especially to run the tests.

[1]. https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations