### PR TITLE
set java version of plugin and model to 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,4 @@ subprojects {
         toolVersion '10.9.3'
         maxWarnings = 0
     }
-
-    sourceCompatibility = "11"
-    targetCompatibility = "11"
 }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,0 +1,3 @@
+java {
+  sourceCompatibility = "1.8"
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,6 +13,10 @@ dependencies {
   }
 }
 
+java {
+  sourceCompatibility = "1.8"
+}
+
 jar {
   from {
     configurations.bundled.collect {


### PR DESCRIPTION
Explicitly set the source and target level of model and plugin module to `1.8`. This is to make sure that they can be launched in a Daemon running on a 1.8 JVM.

So far, the server is not required to do that since it can use the same runtime of the JDT.LS, which is 17.