### PR TITLE
fix: Set log root path via system property

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/JavaBspLauncher.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/JavaBspLauncher.java
@@ -27,6 +27,7 @@ public class JavaBspLauncher {
    * Main entry point.
    */
   public static void main(String[] args) {
+    checkRequiredProperties();
     injector = Guice.createInjector(new BspModule());
     Launcher<BuildClient> launcher = createLauncher();
     client = launcher.getRemoteProxy();
@@ -46,5 +47,11 @@ public class JavaBspLauncher {
       .wrapMessages(new ParentProcessWatcher(bspServer))
       .setExceptionHandler(new ExceptionHandler())
       .create();
+  }
+
+  private static void checkRequiredProperties() {
+    if (System.getProperty("buildServerStorage") == null) {
+      throw new IllegalStateException("The property 'buildServerStorage' is not set");
+    }
   }
 }

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,8 +1,7 @@
 <configuration>
-    <property name="LOG_ROOT" value="${user.home}/.bsp/logs" />
     <property name="LOG_FILE" value="application" />
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_ROOT}/${LOG_FILE}.log</file>
+        <file>${buildServerStorage}/${LOG_FILE}.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${LOG_ROOT}/${LOG_FILE}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>

--- a/server/src/test/java/com/microsoft/java/bs/core/JavaBspLauncherTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/JavaBspLauncherTest.java
@@ -1,0 +1,16 @@
+package com.microsoft.java.bs.core;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class JavaBspLauncherTest {
+
+  @Test
+  void testSystemPropertyCheck() {
+    System.clearProperty("buildServerStorage");
+    assertThrows(IllegalStateException.class, () -> {
+      JavaBspLauncher.main(null);
+    });
+  }
+}


### PR DESCRIPTION
The root path will be passed via system property instead.

i.e.

`java -DbuildServerStorage=<ROOT_PATH> ...`