### PR TITLE
fix: Make notification async

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
@@ -81,7 +81,7 @@ public class GradleBuildServer implements BuildServer {
 
   @Override
   public void onBuildInitialized() {
-    handleNotification("build/initialized", lifecycleService::onBuildInitialized);
+    handleNotificationAsync("build/initialized", lifecycleService::onBuildInitialized);
   }
 
   @Override
@@ -179,6 +179,11 @@ public class GradleBuildServer implements BuildServer {
   private void handleNotification(String methodName, Runnable runnable) {
     logger.info(">> {} received.", methodName);
     runnable.run();
+  }
+
+  private void handleNotificationAsync(String methodName, Runnable runnable) {
+    logger.info(">> {} received.", methodName);
+    CompletableFuture.runAsync(runnable);
   }
 
   private <R> CompletableFuture<R> handleRequest(String methodName,


### PR DESCRIPTION
address https://github.com/microsoft/build-server-for-gradle/pull/49#discussion_r1269168451
I keep the `exit` notification to be sync, because it is the last message to the server.

The `onBuildInitialized` is async now.