### PR TITLE
refactor: Reuse connector for each connection

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/Launcher.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/Launcher.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
 import com.microsoft.java.bs.core.internal.log.LogHandler;
 import com.microsoft.java.bs.core.internal.log.TelemetryHandler;
 import com.microsoft.java.bs.core.internal.managers.BuildTargetManager;
@@ -46,9 +47,11 @@ public class Launcher {
   private static org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> createLauncher() {
     BuildTargetManager buildTargetManager = new BuildTargetManager();
     PreferenceManager preferenceManager = new PreferenceManager();
-    LifecycleService lifecycleService = new LifecycleService(buildTargetManager, preferenceManager);
+    GradleApiConnector connector = new GradleApiConnector(preferenceManager);
+    LifecycleService lifecycleService = new LifecycleService(buildTargetManager,
+        connector, preferenceManager);
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        preferenceManager);
+        connector, preferenceManager);
     GradleBuildServer gradleBuildServer = new GradleBuildServer(lifecycleService,
         buildTargetService);
     return new org.eclipse.lsp4j.jsonrpc.Launcher.Builder<BuildClient>()

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
@@ -44,21 +44,21 @@ public class Utils {
   private static final String GRADLE_USER_HOME = "GRADLE_USER_HOME";
 
   /**
-   * Get the Daemon connection for the project.
+   * Get the Gradle connector for the project.
    *
    * @param projectUri The project uri.
    */ 
-  public static ProjectConnection getProjectConnection(URI projectUri,
+  public static GradleConnector getProjectConnector(URI projectUri,
       Preferences preferences) {
-    return getProjectConnection(new File(projectUri), preferences);
+    return getProjectConnector(new File(projectUri), preferences);
   }
 
   /**
-   * Get the Daemon connection for the project.
+   * Get the Gradle connector for the project.
    *
    * @param project The project.
    */
-  public static ProjectConnection getProjectConnection(File project, Preferences preferences) {
+  public static GradleConnector getProjectConnector(File project, Preferences preferences) {
     GradleConnector connector = GradleConnector.newConnector()
         .forProjectDirectory(project);
 
@@ -79,7 +79,7 @@ public class Utils {
         break;
     }
 
-    return connector.connect();
+    return connector;
   }
 
   /**
@@ -135,22 +135,6 @@ public class Utils {
       launcher.withArguments(gradleArguments);
     }
     return launcher;
-  }
-
-  /**
-   * Get the Gradle version of the project.
-   */
-  public static String getGradleVersion(URI projectUri, Preferences preferences) {
-    try (ProjectConnection connection = Utils.getProjectConnection(projectUri, preferences)) {
-      BuildEnvironment model = connection
-          .model(BuildEnvironment.class)
-          .withArguments("--no-daemon")
-          .get();
-      return model.getGradle().getGradleVersion();
-    } catch (BuildException e) {
-      LOGGER.severe("Failed to get Gradle version: " + e.getMessage());
-      return "";
-    }
   }
 
   /**

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.microsoft.java.bs.core.Launcher;
+import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
 import com.microsoft.java.bs.core.internal.model.Preferences;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
@@ -35,10 +36,20 @@ class GradleApiConnectorTest {
   }
 
   @Test
+  void testGetGradleVersion() {
+    File projectDir = projectPath.resolve("gradle-4.3-with-wrapper").toFile();
+    PreferenceManager preferenceManager = new PreferenceManager();
+    preferenceManager.setPreferences(new Preferences());
+    GradleApiConnector connector = new GradleApiConnector(preferenceManager);
+    assertEquals("4.3", connector.getGradleVersion(projectDir.toURI()));
+  }
+
+  @Test
   void testGetGradleSourceSets() {
     File projectDir = projectPath.resolve("junit5-jupiter-starter-gradle").toFile();
-    Preferences preferences = new Preferences();
-    GradleApiConnector connector = new GradleApiConnector(preferences);
+    PreferenceManager preferenceManager = new PreferenceManager();
+    preferenceManager.setPreferences(new Preferences());
+    GradleApiConnector connector = new GradleApiConnector(preferenceManager);
     GradleSourceSets gradleSourceSets = connector.getGradleSourceSets(projectDir.toURI());
     assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
     for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/UtilsTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/UtilsTest.java
@@ -38,11 +38,6 @@ class UtilsTest {
   }
 
   @Test
-  void testGetGradleVersion() {
-    assertEquals("4.3", Utils.getGradleVersion(projectDir.toURI(), new Preferences()));
-  }
-
-  @Test
   void testPreferencesPriority_wrapperEnabled() {
     Preferences preferences = mock(Preferences.class);
     when(preferences.isWrapperEnabled()).thenReturn(true);

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.microsoft.java.bs.core.Launcher;
+import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
 import com.microsoft.java.bs.core.internal.managers.BuildTargetManager;
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
 import com.microsoft.java.bs.core.internal.services.BuildTargetService;
@@ -46,9 +47,11 @@ class BuildTargetServerIntegrationTest {
   void setUp() {
     BuildTargetManager buildTargetManager = new BuildTargetManager();
     PreferenceManager preferenceManager = new PreferenceManager();
-    LifecycleService lifecycleService = new LifecycleService(buildTargetManager, preferenceManager);
+    GradleApiConnector connector = new GradleApiConnector(preferenceManager);
+    LifecycleService lifecycleService = new LifecycleService(buildTargetManager,
+        connector, preferenceManager);
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        preferenceManager);
+        connector, preferenceManager);
     gradleBuildServer = new GradleBuildServer(lifecycleService, buildTargetService);
   }
 

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
 import com.microsoft.java.bs.core.internal.managers.BuildTargetManager;
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
 import com.microsoft.java.bs.core.internal.model.GradleBuildTarget;
@@ -48,12 +49,13 @@ import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 class BuildTargetServiceTest {
 
   private BuildTargetManager buildTargetManager;
+  private GradleApiConnector connector;
   private PreferenceManager preferenceManager;
 
   @BeforeEach
   void setUp() {
     buildTargetManager = mock(BuildTargetManager.class);
-
+    connector = mock(GradleApiConnector.class);
     preferenceManager = mock(PreferenceManager.class);
     Preferences preferences = new Preferences();
     when(preferenceManager.getPreferences()).thenReturn(preferences);
@@ -69,7 +71,7 @@ class BuildTargetServiceTest {
         .thenReturn(Arrays.asList(gradleBuildTarget));
     
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        preferenceManager);
+        connector, preferenceManager);
 
     WorkspaceBuildTargetsResult response = buildTargetService.getWorkspaceBuildTargets();
 
@@ -97,7 +99,7 @@ class BuildTargetServiceTest {
     when(gradleSourceSet.getGeneratedSourceDirs()).thenReturn(generatedSrcDirs);
 
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        preferenceManager);
+        connector, preferenceManager);
     SourcesResult buildTargetSources = buildTargetService.getBuildTargetSources(new SourcesParams(
             Arrays.asList(new BuildTargetIdentifier("test"))));
     buildTargetSources.getItems().forEach(item -> {
@@ -126,7 +128,7 @@ class BuildTargetServiceTest {
     when(gradleSourceSet.getResourceDirs()).thenReturn(resourceDirs);
 
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        preferenceManager);
+        connector, preferenceManager);
     ResourcesResult buildTargetResources = buildTargetService.getBuildTargetResources(
         new ResourcesParams(Arrays.asList(new BuildTargetIdentifier("test"))));
     buildTargetResources.getItems().forEach(item -> {
@@ -150,7 +152,7 @@ class BuildTargetServiceTest {
     when(gradleSourceSet.getResourceOutputDir()).thenReturn(resourceOutputDir);
 
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        preferenceManager);
+        connector, preferenceManager);
     OutputPathsResult  outputPathsResult = buildTargetService.getBuildTargetOutputPaths(
         new OutputPathsParams(Arrays.asList(new BuildTargetIdentifier("test"))));
     assertEquals(1, outputPathsResult.getItems().size());
@@ -201,7 +203,7 @@ class BuildTargetServiceTest {
     when(gradleSourceSet.getModuleDependencies()).thenReturn(moduleDependencies);
 
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        preferenceManager);
+        connector, preferenceManager);
     DependencyModulesResult res = buildTargetService.getBuildTargetDependencyModules(
         new DependencyModulesParams(Arrays.asList(new BuildTargetIdentifier("test"))));
     assertEquals(1, res.getItems().size());
@@ -234,7 +236,7 @@ class BuildTargetServiceTest {
     when(gradleSourceSet.getCompilerArgs()).thenReturn(compilerArgs);
 
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        preferenceManager);
+        connector, preferenceManager);
     JavacOptionsResult javacOptions = buildTargetService.getBuildTargetJavacOptions(
         new JavacOptionsParams(Arrays.asList(new BuildTargetIdentifier("test"))));
   

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/LifecycleServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/LifecycleServiceTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import com.microsoft.java.bs.core.Constants;
+import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
 import com.microsoft.java.bs.core.internal.managers.BuildTargetManager;
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
 import com.microsoft.java.bs.core.internal.model.Preferences;
@@ -69,7 +70,7 @@ class LifecycleServiceTest {
 
     PreferenceManager preferenceManager = new PreferenceManager();
     LifecycleService lifecycleService = new LifecycleService(mock(BuildTargetManager.class),
-        preferenceManager);
+        mock(GradleApiConnector.class), preferenceManager);
     lifecycleService.initializePreferenceManager(params);
 
     assertEquals("8.1", preferenceManager.getPreferences().getGradleVersion());


### PR DESCRIPTION
- Before this commit, each time connecting to Gradle Daemon, we will create a new connector, which wastes the resources. This commit caches the connector and reuse it for the same project directory.