### PR TITLE
fix: Plugin with id xxx not found

### DIFF
--- a/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/PluginHelper.java
+++ b/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/PluginHelper.java
@@ -21,16 +21,14 @@ public class PluginHelper {
     File pluginJarFile = Paths.get(System.getProperty("user.dir"),
         "build", "libs", "plugin.jar").toFile();
     String pluginJarUnixPath = pluginJarFile.getAbsolutePath().replace("\\", "/");
-    String initScriptContent = 
+    String initScriptContent =
         "initscript {\n"
         + "  dependencies {\n"
         + "    classpath files('%s')\n"
         + "  }\n"
         + "}\n"
         + "allprojects {\n"
-        + "  afterEvaluate {\n"
-        + "    it.getPlugins().apply(com.microsoft.java.bs.gradle.plugin.GradleBuildServerPlugin)\n"
-        + "  }\n"
+        + "  apply plugin: com.microsoft.java.bs.gradle.plugin.GradleBuildServerPlugin\n"
         + "}\n";
     initScriptContent = String.format(initScriptContent, pluginJarUnixPath);
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,9 +41,7 @@ task generateInitScript() {
         }
       }
       allprojects {
-        afterEvaluate {
-          it.getPlugins().apply(com.microsoft.java.bs.gradle.plugin.GradleBuildServerPlugin)
-        }
+        apply plugin: com.microsoft.java.bs.gradle.plugin.GradleBuildServerPlugin
       }
       """
   }


### PR DESCRIPTION
- Apply the plugin at beginning instead of after evaluation. This should
  fix the error 'Plugin with id xxx not found'. The evaluation stage is used
  to resolve all the tasks and the task dependency graph, which does not
  have impact on the classpath information.

Reference: https://github.com/eclipse/buildship/blob/master/samples/custom-tapi-model/org.eclipse.buildship.sample.custommodel/src/org/eclipse/buildship/sample/JavaPluginInfoLoader.java#L57-L59