### PR TITLE
fix: No builders are available to build a model of type xxx

### DIFF
--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPlugin.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPlugin.java
@@ -22,6 +22,6 @@ public class GradleBuildServerPlugin implements Plugin<Project> {
 
   @Override
   public void apply(Project project) {
-    project.afterEvaluate(p -> registry.register(new SourceSetsModelBuilder()));
+    registry.register(new SourceSetsModelBuilder());
   }
 }


### PR DESCRIPTION
- Register the model build before evaluation. This is to fix the error: 'No builders are available to build a model of type xxx.'

reference: https://github.com/eclipse/buildship/blob/b848d9a08283b68860671a73ceec3c99bdab27c2/samples/custom-tapi-model/org.eclipse.buildship.sample.custommodel/custom-model/plugin/src/main/java/org/gradle/sample/plugins/toolingapi/custom/ToolingApiCustomModelPlugin.java#L26