### PR TITLE
fix: No such method error: CompileOptions.getAnnotationProcessorGeneratedSourcesDirectory()

### DIFF
--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -170,13 +170,12 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
     JavaCompile javaCompile = getJavaCompileTask(project, sourceSet);
     if (javaCompile != null) {
       CompileOptions options = javaCompile.getOptions();
-      try {
+      if (GradleVersion.current().compareTo(GradleVersion.version("6.3")) >= 0) {
         Directory generatedDir = options.getGeneratedSourceOutputDirectory().getOrNull();
         if (generatedDir != null) {
           generatedSrcDirs.add(generatedDir.getAsFile());
         }
-      } catch (NoSuchMethodError e) {
-        // to be compatible with Gradle < 6.3
+      } else if (GradleVersion.current().compareTo(GradleVersion.version("4.3")) >= 0) {
         File generatedDir = options.getAnnotationProcessorGeneratedSourcesDirectory();
         if (generatedDir != null) {
           generatedSrcDirs.add(generatedDir);

--- a/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPluginTest.java
+++ b/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPluginTest.java
@@ -112,6 +112,24 @@ class GradleBuildServerPluginTest {
   }
 
   @Test
+  @EnabledOnJre({JRE.JAVA_8})
+  void testGetAnnotationProcessorGeneratedLocation() throws IOException {
+    // this test case is to ensure that the plugin won't throw no such method error
+    // for JavaCompile.getAnnotationProcessorGeneratedSourcesDirectory()
+    File projectDir = projectPath.resolve("legacy-gradle").toFile();
+    GradleConnector connector = GradleConnector.newConnector()
+        .forProjectDirectory(projectDir)
+        .useGradleVersion("4.2.1");
+    try (ProjectConnection connect = connector.connect()) {
+      File initScript = PluginHelper.getInitScript();
+      GradleSourceSets gradleSourceSets = connect.model(GradleSourceSets.class)
+          .addArguments("--init-script", initScript.getAbsolutePath())
+          .get();
+      assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
+    }
+  }
+
+  @Test
   void testSourceInference() throws IOException {
     File projectDir = projectPath.resolve("infer-source-roots").toFile();
     GradleConnector connector = GradleConnector.newConnector().forProjectDirectory(projectDir);


### PR DESCRIPTION
`options.getAnnotationProcessorGeneratedSourcesDirectory()` only exists since `4.3`. For Gradle earlier than this version, skip it.