### PR TITLE
Populate buildTarget/displayName

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
@@ -14,6 +14,11 @@ import java.util.Set;
 public interface GradleSourceSet extends Serializable {
 
   /**
+   * A unique name for this project/sourceSet combination.
+   */
+  public String getDisplayName();
+
+  /**
    * Equivalent to {@code org.gradle.api.Project.getName()}. 
    */
   public String getProjectName();

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -19,6 +19,8 @@ import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 public class DefaultGradleSourceSet implements GradleSourceSet {
   private static final long serialVersionUID = 1L;
 
+  private String displayName;
+
   private String projectName;
 
   private String projectPath;
@@ -65,6 +67,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
    * @param gradleSourceSet the source set to copy from.
    */
   public DefaultGradleSourceSet(GradleSourceSet gradleSourceSet) {
+    this.displayName = gradleSourceSet.getDisplayName();
     this.projectName = gradleSourceSet.getProjectName();
     this.projectPath = gradleSourceSet.getProjectPath();
     this.projectDir = gradleSourceSet.getProjectDir();
@@ -86,6 +89,14 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         .map(DefaultGradleModuleDependency::new).collect(Collectors.toSet());
     this.projectDependencies = gradleSourceSet.getProjectDependencies().stream()
         .map(DefaultGradleProjectDependency::new).collect(Collectors.toSet());
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
   }
 
   public String getProjectName() {
@@ -242,7 +253,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   @Override
   public int hashCode() {
-    return Objects.hash(projectName, projectPath, projectDir,
+    return Objects.hash(displayName, projectName, projectPath, projectDir,
         rootDir, sourceSetName, classesTaskName, sourceDirs,
         generatedSourceDirs, sourceOutputDir, resourceDirs,
         resourceOutputDir, javaHome, javaVersion, gradleVersion,
@@ -262,7 +273,8 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
       return false;
     }
     DefaultGradleSourceSet other = (DefaultGradleSourceSet) obj;
-    return Objects.equals(projectName, other.projectName)
+    return Objects.equals(displayName, other.displayName)
+        && Objects.equals(projectName, other.projectName)
         && Objects.equals(projectPath, other.projectPath)
         && Objects.equals(projectDir, other.projectDir)
         && Objects.equals(rootDir, other.rootDir)

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
@@ -65,6 +65,7 @@ public class BuildTargetManager {
           )
       );
       bt.setBaseDirectory(sourceSet.getRootDir().toURI().toString());
+      bt.setDisplayName(sourceSet.getDisplayName());
 
       setJvmBuildTarget(sourceSet, bt);
 

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
@@ -32,6 +32,7 @@ class BuildTargetManagerTest {
   void testStore() {
     GradleSourceSet gradleSourceSet = getMockedTestGradleSourceSet();
     when(gradleSourceSet.getSourceSetName()).thenReturn("test");
+    when(gradleSourceSet.getDisplayName()).thenReturn("test name");
     GradleSourceSets gradleSourceSets = mock(GradleSourceSets.class);
     when(gradleSourceSets.getGradleSourceSets()).thenReturn(Arrays.asList(gradleSourceSet));
 
@@ -42,6 +43,7 @@ class BuildTargetManagerTest {
     BuildTarget buildTarget = list.get(0).getBuildTarget();
     assertTrue(buildTarget.getTags().contains("test"));
     assertTrue(buildTarget.getId().getUri().contains("?sourceset=test"));
+    assertEquals("test name", buildTarget.getDisplayName());
   }
 
   @Test

--- a/testProjects/duplicate-nested-project-names/a/b/c/src/main/java/com/example/a/MainClass.java
+++ b/testProjects/duplicate-nested-project-names/a/b/c/src/main/java/com/example/a/MainClass.java
@@ -1,0 +1,5 @@
+package com.example.a;
+
+public class MainClass {
+  // do nothing
+}

--- a/testProjects/duplicate-nested-project-names/a/build.gradle
+++ b/testProjects/duplicate-nested-project-names/a/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+	id 'java'
+	id 'java-gradle-plugin'
+}

--- a/testProjects/duplicate-nested-project-names/b-test/build.gradle
+++ b/testProjects/duplicate-nested-project-names/b-test/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+	id 'java'
+	id 'java-gradle-plugin'
+}

--- a/testProjects/duplicate-nested-project-names/b-test/src/main/java/com/example/btest/MainClass.java
+++ b/testProjects/duplicate-nested-project-names/b-test/src/main/java/com/example/btest/MainClass.java
@@ -1,0 +1,5 @@
+package com.example.btest;
+
+public class MainClass {
+  // do nothing
+}

--- a/testProjects/duplicate-nested-project-names/b/build.gradle
+++ b/testProjects/duplicate-nested-project-names/b/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+	id 'java'
+	id 'java-gradle-plugin'
+}

--- a/testProjects/duplicate-nested-project-names/b/src/main/java/com/example/b/MainClass.java
+++ b/testProjects/duplicate-nested-project-names/b/src/main/java/com/example/b/MainClass.java
@@ -1,0 +1,5 @@
+package com.example.b;
+
+public class MainClass {
+  // do nothing
+}

--- a/testProjects/duplicate-nested-project-names/c/build.gradle
+++ b/testProjects/duplicate-nested-project-names/c/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+	id 'java'
+	id 'java-gradle-plugin'
+}

--- a/testProjects/duplicate-nested-project-names/c/src/main/java/com/example/c/MainClass.java
+++ b/testProjects/duplicate-nested-project-names/c/src/main/java/com/example/c/MainClass.java
@@ -1,0 +1,5 @@
+package com.example.c;
+
+public class MainClass {
+  // do nothing
+}

--- a/testProjects/duplicate-nested-project-names/d/build.gradle
+++ b/testProjects/duplicate-nested-project-names/d/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+	id 'java'
+	id 'java-gradle-plugin'
+}

--- a/testProjects/duplicate-nested-project-names/d/foo/src/main/java/com/example/foo/MainClass.java
+++ b/testProjects/duplicate-nested-project-names/d/foo/src/main/java/com/example/foo/MainClass.java
@@ -1,0 +1,5 @@
+package com.example.foo;
+
+public class MainClass {
+  // do nothing
+}

--- a/testProjects/duplicate-nested-project-names/e/build.gradle
+++ b/testProjects/duplicate-nested-project-names/e/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+	id 'java'
+	id 'java-gradle-plugin'
+}

--- a/testProjects/duplicate-nested-project-names/e/foo/src/main/java/com/example/foo/MainClass.java
+++ b/testProjects/duplicate-nested-project-names/e/foo/src/main/java/com/example/foo/MainClass.java
@@ -1,0 +1,5 @@
+package com.example.foo;
+
+public class MainClass {
+  // do nothing
+}

--- a/testProjects/duplicate-nested-project-names/settings.gradle
+++ b/testProjects/duplicate-nested-project-names/settings.gradle
@@ -1,0 +1,7 @@
+rootProject.name = 'duplicate-names'
+include 'a:b:c'
+include 'b'
+include 'b-test'
+include 'c'
+include 'd:foo'
+include 'e:foo'


### PR DESCRIPTION
This PR populates display name in `BuildTarget` which is currently null.

Creating unique names is a bit fiddly as BSP considers each source set a separate target and unique whereas Gradle considers each project unique.  I've added a test for this.