### PR TITLE
fix: Populate test tag correctly for all sourcesets

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
@@ -118,4 +118,9 @@ public interface GradleSourceSet extends Serializable {
    * Project dependencies.
    */
   public Set<GradleProjectDependency> getProjectDependencies();
+
+  /**
+   * has tests defined.
+   */
+  public boolean hasTests();
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -61,6 +61,8 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   private Set<GradleProjectDependency> projectDependencies;
 
+  private boolean hasTests;
+
   public DefaultGradleSourceSet() {}
 
   /**
@@ -92,6 +94,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         .map(DefaultGradleModuleDependency::new).collect(Collectors.toSet());
     this.projectDependencies = gradleSourceSet.getProjectDependencies().stream()
         .map(DefaultGradleProjectDependency::new).collect(Collectors.toSet());
+    this.hasTests = gradleSourceSet.hasTests();
   }
 
   public String getDisplayName() {
@@ -262,6 +265,14 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
     this.projectDependencies = projectDependencies;
   }
 
+  public boolean hasTests() {
+    return hasTests;
+  }
+
+  public void setHasTests(boolean hasTests) {
+    this.hasTests = hasTests;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(displayName, projectName, projectPath, projectDir,
@@ -269,7 +280,8 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         generatedSourceDirs, sourceOutputDir, compileClasspath,
         resourceDirs, resourceOutputDir, javaHome, javaVersion,
         gradleVersion, sourceCompatibility, targetCompatibility,
-        compilerArgs, moduleDependencies, projectDependencies);
+        compilerArgs, moduleDependencies, projectDependencies,
+        hasTests);
   }
 
   @Override
@@ -304,6 +316,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         && Objects.equals(targetCompatibility, other.targetCompatibility)
         && Objects.equals(compilerArgs, other.compilerArgs)
         && Objects.equals(moduleDependencies, other.moduleDependencies)
-        && Objects.equals(projectDependencies, other.projectDependencies);
+        && Objects.equals(projectDependencies, other.projectDependencies)
+        && hasTests == other.hasTests;
   }
 }

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -22,12 +22,15 @@ import java.util.regex.Pattern;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.plugins.ide.internal.tooling.java.DefaultInstalledJdk;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 import org.gradle.util.GradleVersion;
@@ -117,6 +120,18 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
         gradleSourceSet.setTargetCompatibility(getTargetCompatibility(project, sourceSet));
         gradleSourceSet.setCompilerArgs(getCompilerArgs(project, sourceSet));
         gradleSourceSets.add(gradleSourceSet);
+
+        // tests
+        if (sourceOutputDir != null) {
+          TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
+          for (Test testTask : testTasks) {
+            FileCollection files = testTask.getTestClassesDirs();
+            if (files.contains(sourceOutputDir)) {
+              gradleSourceSet.setHasTests(true);
+              break;
+            }
+          }
+        }
       });
     }
 

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
@@ -50,7 +50,7 @@ public class BuildTargetManager {
     for (GradleSourceSet sourceSet : gradleSourceSets.getGradleSourceSets()) {
       String sourceSetName = sourceSet.getSourceSetName();
       URI uri = getBuildTargetUri(sourceSet.getProjectDir().toURI(), sourceSetName);
-      List<String> tags = getBuildTargetTags(sourceSetName);
+      List<String> tags = getBuildTargetTags(sourceSet.hasTests());
       BuildTargetIdentifier btId = new BuildTargetIdentifier(uri.toString());
       BuildTarget bt = new BuildTarget(
           btId,
@@ -101,9 +101,9 @@ public class BuildTargetManager {
     return URI.create(projectUri.toString() + "?sourceset=" + sourceSetName);
   }
 
-  private List<String> getBuildTargetTags(String sourceSetName) {
+  private List<String> getBuildTargetTags(boolean hasTests) {
     List<String> tags = new ArrayList<>();
-    if (sourceSetName.toLowerCase().contains(BuildTargetTag.TEST)) {
+    if (hasTests) {
       tags.add(BuildTargetTag.TEST);
     }
     return tags;

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
@@ -33,6 +33,7 @@ class BuildTargetManagerTest {
     GradleSourceSet gradleSourceSet = getMockedTestGradleSourceSet();
     when(gradleSourceSet.getSourceSetName()).thenReturn("test");
     when(gradleSourceSet.getDisplayName()).thenReturn("test name");
+    when(gradleSourceSet.hasTests()).thenReturn(true);
     GradleSourceSets gradleSourceSets = mock(GradleSourceSets.class);
     when(gradleSourceSets.getGradleSourceSets()).thenReturn(Arrays.asList(gradleSourceSet));
 

--- a/testProjects/test-tag/build.gradle
+++ b/testProjects/test-tag/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+	id 'java'
+	id 'java-gradle-plugin'
+	id 'java-test-fixtures'
+}
+
+sourceSets {
+  intTest {
+    compileClasspath += sourceSets.main.output
+    runtimeClasspath += sourceSets.main.output
+  }
+  noTests {
+    compileClasspath += sourceSets.main.output
+    runtimeClasspath += sourceSets.main.output
+  }
+}
+
+configurations {
+  intTestImplementation.extendsFrom implementation
+  intTestRuntimeOnly.extendsFrom runtimeOnly
+  noTestsImplementation.extendsFrom implementation
+  noTestsRuntimeOnly.extendsFrom runtimeOnly
+}
+
+task integrationTest(type: Test) {
+  testClassesDirs = sourceSets.intTest.output.classesDirs
+}

--- a/testProjects/test-tag/settings.gradle
+++ b/testProjects/test-tag/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'test-tag'

--- a/testProjects/test-tag/src/main/java/com/example/project/MainClass.java
+++ b/testProjects/test-tag/src/main/java/com/example/project/MainClass.java
@@ -1,0 +1,5 @@
+package com.example.project;
+
+public class MainClass {
+
+}

--- a/testProjects/test-tag/src/test/java/com/example/project/TestClass.java
+++ b/testProjects/test-tag/src/test/java/com/example/project/TestClass.java
@@ -1,0 +1,5 @@
+package com.example.project;
+
+class TestClass {
+
+}


### PR DESCRIPTION
Currently the BSP `BuildTargetTag` tag is populated as `Test` only when the source set name is `test`.

All other build targets won't have this tag, which means other test configurations (e.g. integration tests) won't have the tag.

Now the code checks to see if there is a `Test` task associated with the source set and populates the tag from that information.