### PR TITLE
Add Kotlin support

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/KotlinExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/KotlinExtension.java
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model;
+
+import java.util.List;
+
+/**
+ * The extension model for Kotlin language.
+ */
+public interface KotlinExtension extends LanguageExtension {
+
+  String getKotlinLanguageVersion();
+  
+  String getKotlinApiVersion();
+  
+  List<String> getKotlincOptions();
+  
+  List<String> getKotlinAssociates();
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/LanguageExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/LanguageExtension.java
@@ -58,6 +58,13 @@ public interface LanguageExtension extends Serializable {
   boolean isScalaExtension();
 
   /**
+   * Checks if the implementing class is a {@link ScalaExtension}.
+   *
+   * @return true if the extension is for Scala, false otherwise.
+   */
+  boolean isKotlinExtension();
+
+  /**
    * Attempts to cast the current object to a {@link JavaExtension} instance.
    * <p>
    * This method should ideally be used only when the implementing class
@@ -80,4 +87,17 @@ public interface LanguageExtension extends Serializable {
    *        or null if the cast fails.
    */
   ScalaExtension getAsScalaExtension();
+
+  /**
+   * Attempts to cast the current object to a {@link KotlinExtension} instance.
+   * <p>
+   * This method should ideally be used only when the implementing class
+   * is known to be a {@link KotlinExtension}.
+   * </p>
+   *
+   * @return the current object cast to a {@link KotlinExtension} instance,
+   *        or null if the cast fails.
+   */
+  KotlinExtension getAsKotlinExtension();
+
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/SupportedLanguages.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/SupportedLanguages.java
@@ -4,6 +4,7 @@
 package com.microsoft.java.bs.gradle.model;
 
 import com.microsoft.java.bs.gradle.model.impl.DefaultJavaLanguage;
+import com.microsoft.java.bs.gradle.model.impl.DefaultKotlinLanguage;
 import com.microsoft.java.bs.gradle.model.impl.DefaultScalaLanguage;
 
 import java.util.LinkedList;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 public class SupportedLanguages {
   public static final DefaultJavaLanguage JAVA = new DefaultJavaLanguage();
   public static final DefaultScalaLanguage SCALA = new DefaultScalaLanguage();
+  public static final DefaultKotlinLanguage KOTLIN = new DefaultKotlinLanguage();
 
   public static final List<SupportedLanguage<?>> all;
   public static final List<String> allBspNames;
@@ -24,6 +26,7 @@ public class SupportedLanguages {
     all = new LinkedList<>();
     all.add(JAVA);
     all.add(SCALA);
+    all.add(KOTLIN);
     allBspNames = all.stream().map(SupportedLanguage::getBspName).collect(Collectors.toList());
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -107,6 +107,10 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
       return object.getAsScalaExtension();
     }
 
+    if (object.isKotlinExtension()) {
+      return object.getAsKotlinExtension();
+    }
+
     throw new IllegalArgumentException("No conversion methods defined for object: " + object);
   }
 

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultJavaExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultJavaExtension.java
@@ -4,6 +4,7 @@
 package com.microsoft.java.bs.gradle.model.impl;
 
 import com.microsoft.java.bs.gradle.model.JavaExtension;
+import com.microsoft.java.bs.gradle.model.KotlinExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 
 import java.io.File;
@@ -156,12 +157,22 @@ public class DefaultJavaExtension implements JavaExtension {
   }
 
   @Override
+  public boolean isKotlinExtension() {
+    return false;
+  }
+
+  @Override
   public JavaExtension getAsJavaExtension() {
     return this;
   }
 
   @Override
   public ScalaExtension getAsScalaExtension() {
+    return null;
+  }
+
+  @Override
+  public KotlinExtension getAsKotlinExtension() {
     return null;
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultKotlinExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultKotlinExtension.java
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model.impl;
+
+import com.microsoft.java.bs.gradle.model.JavaExtension;
+import com.microsoft.java.bs.gradle.model.KotlinExtension;
+import com.microsoft.java.bs.gradle.model.ScalaExtension;
+
+import java.io.File;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Default implementation of {@link KotlinExtension}.
+ */
+public class DefaultKotlinExtension implements KotlinExtension {
+  private static final long serialVersionUID = 1L;
+  
+  private Set<File> sourceDirs;
+
+  private Set<File> generatedSourceDirs;
+
+  private String compileTaskName;
+
+  private File classesDir;
+
+  private String kotlinLanguageVersion;
+
+  private String kotlinApiVersion;
+
+  private List<String> kotlincOptions;
+
+  private List<String> kotlinAssociates;
+
+  @Override
+  public Set<File> getSourceDirs() {
+    return sourceDirs;
+  }
+
+  public void setSourceDirs(Set<File> sourceDirs) {
+    this.sourceDirs = sourceDirs;
+  }
+
+  @Override
+  public Set<File> getGeneratedSourceDirs() {
+    return generatedSourceDirs;
+  }
+
+  public void setGeneratedSourceDirs(Set<File> generatedSourceDirs) {
+    this.generatedSourceDirs = generatedSourceDirs;
+  }
+
+  @Override
+  public String getCompileTaskName() {
+    return compileTaskName;
+  }
+
+  public void setCompileTaskName(String compileTaskName) {
+    this.compileTaskName = compileTaskName;
+  }
+
+  @Override
+  public File getClassesDir() {
+    return classesDir;
+  }
+
+  public void setClassesDir(File classesDir) {
+    this.classesDir = classesDir;
+  }
+
+  @Override
+  public String getKotlinLanguageVersion() {
+    return kotlinLanguageVersion;
+  }
+
+  public void setKotlinLanguageVersion(String kotlinLanguageVersion) {
+    this.kotlinLanguageVersion = kotlinLanguageVersion;
+  }
+
+  @Override
+  public String getKotlinApiVersion() {
+    return kotlinApiVersion;
+  }
+
+  public void setKotlinApiVersion(String kotlinApiVersion) {
+    this.kotlinApiVersion = kotlinApiVersion;
+  }
+
+  @Override
+  public List<String> getKotlincOptions() {
+    return kotlincOptions;
+  }
+
+  public void setKotlincOptions(List<String> kotlincOptions) {
+    this.kotlincOptions = kotlincOptions;
+  }
+
+  @Override
+  public List<String> getKotlinAssociates() {
+    return kotlinAssociates;
+  }
+
+  public void setKotlinAssociates(List<String> kotlinAssociates) {
+    this.kotlinAssociates = kotlinAssociates;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceDirs, generatedSourceDirs, compileTaskName, classesDir,
+              kotlinLanguageVersion, kotlinApiVersion, kotlincOptions, kotlinAssociates);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    DefaultKotlinExtension other = (DefaultKotlinExtension) obj;
+    return Objects.equals(sourceDirs, other.sourceDirs)
+            && Objects.equals(generatedSourceDirs, other.generatedSourceDirs)
+            && Objects.equals(compileTaskName, other.compileTaskName)
+            && Objects.equals(classesDir, other.classesDir)
+            && Objects.equals(kotlinLanguageVersion, other.kotlinLanguageVersion)
+            && Objects.equals(kotlinApiVersion, other.kotlinApiVersion)
+            && Objects.equals(kotlincOptions, other.kotlincOptions)
+            && Objects.equals(kotlinAssociates, other.kotlinAssociates);
+  }
+
+  @Override
+  public boolean isJavaExtension() {
+    return false;
+  }
+
+  @Override
+  public boolean isScalaExtension() {
+    return false;
+  }
+
+  @Override
+  public boolean isKotlinExtension() {
+    return true;
+  }
+
+  @Override
+  public JavaExtension getAsJavaExtension() {
+    return null;
+  }
+
+  @Override
+  public ScalaExtension getAsScalaExtension() {
+    return null;
+  }
+
+  @Override
+  public KotlinExtension getAsKotlinExtension() {
+    return this;
+  }
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultKotlinLanguage.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultKotlinLanguage.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model.impl;
+
+import com.microsoft.java.bs.gradle.model.KotlinExtension;
+import com.microsoft.java.bs.gradle.model.LanguageExtension;
+import com.microsoft.java.bs.gradle.model.SupportedLanguage;
+
+import java.util.Map;
+
+/**
+ * Default Kotlin implementation of {@link SupportedLanguage}.
+ */
+public class DefaultKotlinLanguage implements SupportedLanguage<KotlinExtension> {
+
+  @Override
+  public String getBspName() {
+    return "kotlin";
+  }
+
+  @Override
+  public String getGradleName() {
+    return "kotlin";
+  }
+
+  @Override
+  public KotlinExtension getExtension(Map<String, LanguageExtension> extensions) {
+    LanguageExtension extension = extensions.get(getBspName());
+    if (extension == null) {
+      return null;
+    }
+    if (extension.isKotlinExtension()) {
+      return extension.getAsKotlinExtension();
+    }
+    throw new IllegalArgumentException(
+        "LanguageExtension: " + extension + " is not a KotlinExtension."
+    );
+  }
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultScalaExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultScalaExtension.java
@@ -4,6 +4,7 @@
 package com.microsoft.java.bs.gradle.model.impl;
 
 import com.microsoft.java.bs.gradle.model.JavaExtension;
+import com.microsoft.java.bs.gradle.model.KotlinExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 
 import java.io.File;
@@ -156,6 +157,11 @@ public class DefaultScalaExtension implements ScalaExtension {
   }
 
   @Override
+  public boolean isKotlinExtension() {
+    return false;
+  }
+
+  @Override
   public JavaExtension getAsJavaExtension() {
     return null;
   }
@@ -163,5 +169,10 @@ public class DefaultScalaExtension implements ScalaExtension {
   @Override
   public ScalaExtension getAsScalaExtension() {
     return this;
+  }
+
+  @Override
+  public KotlinExtension getAsKotlinExtension() {
+    return null;
   }
 }

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/KotlinLanguageModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/KotlinLanguageModelBuilder.java
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.plugin;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
+import com.microsoft.java.bs.gradle.model.KotlinExtension;
+import com.microsoft.java.bs.gradle.model.SupportedLanguage;
+import com.microsoft.java.bs.gradle.model.impl.DefaultKotlinExtension;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.util.GradleVersion;
+
+import com.microsoft.java.bs.gradle.model.SupportedLanguages;
+
+/**
+ * The language model builder for Kotlin language.
+ * Kotlin plugin is not built-in to Gradle so Reflection is used to query info.
+ */
+public class KotlinLanguageModelBuilder extends LanguageModelBuilder {
+
+  @Override
+  public SupportedLanguage<KotlinExtension> getLanguage() {
+    return SupportedLanguages.KOTLIN;
+  }
+
+  private Set<File> getSourceFolders(SourceSet sourceSet) {
+    if (GradleVersion.current().compareTo(GradleVersion.version("7.1")) >= 0) {
+      SourceDirectorySet sourceDirectorySet = (SourceDirectorySet)
+          sourceSet.getExtensions().findByName("kotlin");
+      return sourceDirectorySet == null ? Collections.emptySet() : sourceDirectorySet.getSrcDirs();
+    } else {
+      // there is no way pre-Gradle 7.1 to get the kotlin source dirs separately from other
+      // languages.  Luckily source dirs from all languages are jumbled together in BSP,
+      // so we can just reply with all.
+      // resource dirs must be removed.
+      Set<File> allSource = sourceSet.getAllSource().getSrcDirs();
+      Set<File> allResource = sourceSet.getResources().getSrcDirs();
+      return allSource.stream().filter(dir -> !allResource.contains(dir))
+        .collect(Collectors.toSet());
+    }
+  }
+
+  private Task getKotlinCompileTask(Project project, SourceSet sourceSet) {
+    return getLanguageCompileTask(project, sourceSet);
+  }
+
+  @Override
+  public DefaultKotlinExtension getExtensionFor(Project project, SourceSet sourceSet,
+                                 Set<GradleModuleDependency> moduleDependencies) {
+    Task kotlinCompile = getKotlinCompileTask(project, sourceSet);
+    if (kotlinCompile != null) {
+      DefaultKotlinExtension extension = new DefaultKotlinExtension();
+
+      extension.setCompileTaskName(kotlinCompile.getName());
+
+      extension.setSourceDirs(getSourceFolders(sourceSet));
+      extension.setGeneratedSourceDirs(Collections.emptySet());
+      extension.setClassesDir(getClassesDir(kotlinCompile, sourceSet));
+
+      extension.setKotlinApiVersion(getKotlinApiVersion(kotlinCompile));
+      extension.setKotlinLanguageVersion(getKotlinLanguageVersion(kotlinCompile));
+      extension.setKotlincOptions(getKotlinOptions(kotlinCompile));
+      // TODO - how to set this?
+      // gradleSourceSet.setKotlinAssociates(null);
+      return extension;
+    }
+    return null;
+  }
+
+  private String getKotlinApiVersion(Task kotlinCompile) {
+    // https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
+    // https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCommonCompilerOptions.kt
+    try {
+      Method getCompilerOptionsMethod = kotlinCompile.getClass().getMethod("getCompilerOptions");
+      Object compilerOptions = getCompilerOptionsMethod.invoke(kotlinCompile);
+      Method getApiVersionMethod = compilerOptions.getClass().getMethod("getApiVersion");
+      Object apiVersionProviderObject = getApiVersionMethod.invoke(compilerOptions);
+      if (apiVersionProviderObject instanceof Provider) {
+        Provider<?> apiVersionProvider = (Provider<?>) apiVersionProviderObject;
+        if (apiVersionProvider.isPresent()) {
+          Object apiVersion = apiVersionProvider.get();
+          if (apiVersion != null) {
+            Method versionMethod = apiVersion.getClass().getMethod("getVersion");
+            Object versionMethodObject = versionMethod.invoke(apiVersion);
+            if (versionMethodObject != null) {
+              return versionMethodObject.toString();
+            }
+          }
+        }
+      }
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+             | IllegalArgumentException | InvocationTargetException e) {
+      // ignore
+    }
+    return "";
+  }
+
+  private String getKotlinLanguageVersion(Task kotlinCompile) {
+    // https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
+    // https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCommonCompilerOptions.kt
+    try {
+      Method getCompilerOptionsMethod = kotlinCompile.getClass().getMethod("getCompilerOptions");
+      Object compilerOptions = getCompilerOptionsMethod.invoke(kotlinCompile);
+      Method getLanguageVersionMethod = compilerOptions.getClass().getMethod("getLanguageVersion");
+      Object languageVersionProviderObject = getLanguageVersionMethod.invoke(compilerOptions);
+      if (languageVersionProviderObject instanceof Provider) {
+        Provider<?> languageVersionProvider = (Provider<?>) languageVersionProviderObject;
+        if (languageVersionProvider.isPresent()) {
+          Object languageVersion = languageVersionProvider.get();
+          if (languageVersion != null) {
+            Method versionMethod = languageVersion.getClass().getMethod("getVersion");
+            Object versionMethodObject = versionMethod.invoke(languageVersion);
+            if (versionMethodObject != null) {
+              return versionMethodObject.toString();
+            }
+          }
+        }
+      }
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+             | IllegalArgumentException | InvocationTargetException e) {
+      // ignore
+    }
+    return "";
+  }
+
+  private List<String> getKotlinOptions(Task kotlinCompile) {
+    // https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
+    // https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin-api/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinCommonCompilerOptions.kt
+    try {
+      Method getCompilerOptionsMethod = kotlinCompile.getClass().getMethod("getCompilerOptions");
+      Object compilerOptions = getCompilerOptionsMethod.invoke(kotlinCompile);
+      Method getLanguageVersionMethod = compilerOptions.getClass().getMethod("getFreeCompilerArgs");
+      Object freeCompilerArgsProviderObject = getLanguageVersionMethod.invoke(compilerOptions);
+      if (freeCompilerArgsProviderObject instanceof Provider) {
+        Provider<?> freeCompilerArgsProvider = (Provider<?>) freeCompilerArgsProviderObject;
+        if (freeCompilerArgsProvider.isPresent()) {
+          Object freeCompilerArgs = freeCompilerArgsProvider.get();
+          if (freeCompilerArgs instanceof List) {
+            return ((List<?>) freeCompilerArgs).stream()
+              .map(Object::toString).collect(Collectors.toList());
+          }
+        }
+      }
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+             | IllegalArgumentException | InvocationTargetException e) {
+      // ignore
+    }
+    return null;
+  }
+
+  private File getClassesDir(Task kotlinCompile, SourceSet sourceSet) {
+    if (GradleVersion.current().compareTo(GradleVersion.version("4.2")) >= 0) {
+      // https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt
+      try {
+        Method getDestinationDirectoryMethod = kotlinCompile.getClass().getMethod("getDestinationDirectory");
+        Object destinationDirectory = getDestinationDirectoryMethod.invoke(kotlinCompile);
+        Method getAsFileMethod = destinationDirectory.getClass().getMethod("getAsFile");
+        Object fileProviderObject = getAsFileMethod.invoke(destinationDirectory);
+        if (fileProviderObject instanceof Provider) {
+          Provider<?> fileProvider = (Provider<?>) fileProviderObject;
+          if (fileProvider.isPresent()) {
+            Object file = fileProvider.get();
+            if (file instanceof File) {
+              return (File) file;
+            }
+          }
+        }
+      } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+              | IllegalArgumentException | InvocationTargetException e) {
+        // ignore
+      }
+    }
+    return null;
+  }
+}

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -181,6 +181,8 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
           results.add(new JavaLanguageModelBuilder());
         } else if (language.equalsIgnoreCase(SupportedLanguages.SCALA.getBspName())) {
           results.add(new ScalaLanguageModelBuilder());
+        } else if (language.equalsIgnoreCase(SupportedLanguages.KOTLIN.getBspName())) {
+          results.add(new KotlinLanguageModelBuilder());
         }
       }
     }

--- a/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPluginTest.java
+++ b/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPluginTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
 import com.microsoft.java.bs.gradle.model.JavaExtension;
+import com.microsoft.java.bs.gradle.model.KotlinExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 import com.microsoft.java.bs.gradle.model.actions.GetSourceSetsAction;
@@ -179,6 +180,8 @@ class GradleBuildServerPluginTest {
             || gradleSourceSet.getClassesTaskName().equals(":testClasses"));
         assertFalse(gradleSourceSet.getCompileClasspath().isEmpty());
         assertEquals(1, gradleSourceSet.getSourceDirs().size());
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+            .anyMatch(file -> file.toPath().endsWith("java")));
         // annotation processor dirs weren't auto created before 5.2
         if (gradleVersion.compareTo(GradleVersion.version("5.2")) >= 0) {
           assertEquals(1, gradleSourceSet.getGeneratedSourceDirs().size());
@@ -273,6 +276,7 @@ class GradleBuildServerPluginTest {
       assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
       int generatedSourceDirCount = 0;
       for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {
+        assertEquals(1, gradleSourceSet.getSourceDirs().size());
         generatedSourceDirCount += gradleSourceSet.getGeneratedSourceDirs().size();
         assertTrue(gradleSourceSet.getGeneratedSourceDirs().stream().anyMatch(
             dir -> dir.getAbsolutePath().replaceAll("\\\\", "/")
@@ -478,6 +482,10 @@ class GradleBuildServerPluginTest {
                 || gradleSourceSet.getClassesTaskName().equals(":testClasses"));
         assertFalse(gradleSourceSet.getCompileClasspath().isEmpty());
         assertEquals(2, gradleSourceSet.getSourceDirs().size());
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+            .anyMatch(file -> file.toPath().endsWith("java")));
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+            .anyMatch(file -> file.toPath().endsWith("scala")));
         // annotation processor dirs weren't auto created before 5.2
         if (gradleVersion.compareTo(GradleVersion.version("5.2")) >= 0) {
           assertEquals(1, gradleSourceSet.getGeneratedSourceDirs().size());
@@ -567,6 +575,10 @@ class GradleBuildServerPluginTest {
                 || gradleSourceSet.getClassesTaskName().equals(":testClasses"));
         assertFalse(gradleSourceSet.getCompileClasspath().isEmpty());
         assertEquals(2, gradleSourceSet.getSourceDirs().size());
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+            .anyMatch(file -> file.toPath().endsWith("java")));
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+            .anyMatch(file -> file.toPath().endsWith("scala")));
         // annotation processor dirs weren't auto created before 5.2
         if (gradleVersion.compareTo(GradleVersion.version("5.2")) >= 0) {
           assertEquals(1, gradleSourceSet.getGeneratedSourceDirs().size());
@@ -624,4 +636,78 @@ class GradleBuildServerPluginTest {
       }
     });
   }
+
+  @ParameterizedTest(name = "testKotlinModelBuilder {0}")
+  @MethodSource("versionProvider")
+  void testKotlinModelBuilder(GradleVersion gradleVersion) throws IOException {
+    // can't find a valid compatibility matrix for gradle and kotlin plugin versions
+    // Gradle>7.1 seems to support kotlin-gradle-plugin 1.9.21
+    assumeTrue(gradleVersion.compareTo(GradleVersion.version("7.1")) >= 0);
+    withSourceSets("kotlin", gradleVersion, gradleSourceSets -> {
+      assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
+      for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {
+        assertEquals("kotlin", gradleSourceSet.getProjectName());
+        assertEquals(":", gradleSourceSet.getProjectPath());
+        assertTrue(gradleSourceSet.getSourceSetName().equals("main")
+                || gradleSourceSet.getSourceSetName().equals("test"),
+                "Task name is: " + gradleSourceSet.getClassesTaskName());
+        assertTrue(gradleSourceSet.getClassesTaskName().equals(":classes")
+                || gradleSourceSet.getClassesTaskName().equals(":testClasses"),
+                "Task name is: " + gradleSourceSet.getClassesTaskName());
+        assertFalse(gradleSourceSet.getCompileClasspath().isEmpty());
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+            .anyMatch(file -> file.toPath().endsWith("java")));
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+            .anyMatch(file -> file.toPath().endsWith("kotlin")));
+        assertFalse(gradleSourceSet.getGeneratedSourceDirs().isEmpty());
+        assertFalse(gradleSourceSet.getResourceDirs().isEmpty());
+        assertNotNull(gradleSourceSet.getSourceOutputDirs());
+        assertNotNull(gradleSourceSet.getResourceOutputDir());
+        assertNotNull(gradleSourceSet.getBuildTargetDependencies());
+        assertNotNull(gradleSourceSet.getModuleDependencies());
+        JavaExtension javaExtension = SupportedLanguages.JAVA.getExtension(gradleSourceSet);
+        assertNotNull(javaExtension);
+        assertNotNull(javaExtension.getJavaHome());
+        assertNotNull(javaExtension.getJavaVersion());
+
+        assertTrue(gradleSourceSet.getModuleDependencies().stream().anyMatch(
+                dependency -> dependency.getModule().contains("kotlin-stdlib")
+        ));
+
+        KotlinExtension kotlinExtension = SupportedLanguages.KOTLIN.getExtension(gradleSourceSet);
+        assertNotNull(kotlinExtension);
+        assertEquals("1.2", kotlinExtension.getKotlinApiVersion());
+        assertEquals("1.3", kotlinExtension.getKotlinLanguageVersion());
+        assertFalse(gradleSourceSet.getCompileClasspath().isEmpty());
+        assertTrue(gradleSourceSet.getCompileClasspath().stream().anyMatch(
+                file -> file.getName().equals("kotlin-stdlib-1.9.21.jar")));
+        assertFalse(kotlinExtension.getKotlincOptions().isEmpty());
+        assertTrue(kotlinExtension.getKotlincOptions().stream()
+                .anyMatch(arg -> arg.equals("-opt-in=org.mylibrary.OptInAnnotation")));
+                
+        // dirs not split by language before 4.0
+        if (gradleVersion.compareTo(GradleVersion.version("4.0")) >= 0) {
+          assertTrue(gradleSourceSet.getSourceOutputDirs().stream()
+              .anyMatch(file -> file.toPath().endsWith(Paths.get("classes", "java",
+              gradleSourceSet.getSourceSetName()))));
+          assertTrue(gradleSourceSet.getSourceOutputDirs().stream()
+              .anyMatch(file -> file.toPath().endsWith(Paths.get("classes", "kotlin",
+              gradleSourceSet.getSourceSetName()))));
+          assertTrue(javaExtension.getClassesDir().toPath().endsWith(Paths.get("classes", "java",
+              gradleSourceSet.getSourceSetName())));
+          assertTrue(kotlinExtension.getClassesDir().toPath().endsWith(
+              Paths.get("classes", "kotlin", gradleSourceSet.getSourceSetName())));
+        } else {
+          assertTrue(gradleSourceSet.getSourceOutputDirs().stream()
+              .anyMatch(file -> file.toPath().endsWith(Paths.get("classes",
+              gradleSourceSet.getSourceSetName()))));
+          assertTrue(kotlinExtension.getClassesDir().toPath().endsWith(Paths.get("classes",
+              gradleSourceSet.getSourceSetName())));
+          assertTrue(javaExtension.getClassesDir().toPath().endsWith(Paths.get("classes",
+              gradleSourceSet.getSourceSetName())));
+        }
+      }
+    });
+  }
+
 }

--- a/server/src/main/java/ch/epfl/scala/bsp4j/extended/KotlinBuildTarget.java
+++ b/server/src/main/java/ch/epfl/scala/bsp4j/extended/KotlinBuildTarget.java
@@ -1,0 +1,102 @@
+package ch.epfl.scala.bsp4j.extended;
+
+import java.util.List;
+import java.util.Objects;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.JvmBuildTarget;
+
+/**
+ * Should be possible to remove this when Kotlin is finalised in BSP spec.
+ * See https://github.com/build-server-protocol/build-server-protocol/issues/520
+ */
+public class KotlinBuildTarget {
+  private String languageVersion;
+  private String apiVersion;
+  private List<String> kotlincOptions;
+  private List<BuildTargetIdentifier> associates;
+  private JvmBuildTarget jvmBuildTarget;
+
+  /**
+   * Create a new instance of {@link KotlinBuildTarget}.
+   */
+  public KotlinBuildTarget(String languageVersion, String apiVersion,
+                           List<String> kotlincOptions, List<BuildTargetIdentifier> associates,
+                           JvmBuildTarget jvmBuildTarget) {
+    this.languageVersion = languageVersion;
+    this.apiVersion = apiVersion;
+    this.kotlincOptions = kotlincOptions;
+    this.associates = associates;
+    this.jvmBuildTarget = jvmBuildTarget;
+  }
+
+  public String getLanguageVersion() {
+    return languageVersion;
+  }
+
+  public void setLanguageVersion(String languageVersion) {
+    this.languageVersion = languageVersion;
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public List<String> getKotlincOptions() {
+    return kotlincOptions;
+  }
+
+  public void setKotlincOptions(List<String> kotlincOptions) {
+    this.kotlincOptions = kotlincOptions;
+  }
+
+  public List<BuildTargetIdentifier> getAssociates() {
+    return associates;
+  }
+
+  public void setAssociates(List<BuildTargetIdentifier> associates) {
+    this.associates = associates;
+  }
+
+  public JvmBuildTarget getJvmBuildTarget() {
+    return jvmBuildTarget;
+  }
+
+  public void setJvmBuildTarget(JvmBuildTarget jvmBuildTarget) {
+    this.jvmBuildTarget = jvmBuildTarget;
+  }
+
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + Objects.hash(languageVersion, apiVersion,
+            kotlincOptions, associates, jvmBuildTarget);
+
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!super.equals(obj)) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    KotlinBuildTarget other = (KotlinBuildTarget) obj;
+    return Objects.equals(languageVersion, other.languageVersion)
+            && Objects.equals(apiVersion, other.apiVersion)
+            && Objects.equals(kotlincOptions, other.kotlincOptions)
+            && Objects.equals(associates, other.associates)
+            && Objects.equals(jvmBuildTarget, other.jvmBuildTarget);
+  }
+}

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -19,19 +19,20 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import com.microsoft.java.bs.core.Launcher;
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
 import com.microsoft.java.bs.core.internal.model.Preferences;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
+import com.microsoft.java.bs.gradle.model.KotlinExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.StatusCode;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 class GradleApiConnectorTest {
 
@@ -80,6 +81,7 @@ class GradleApiConnectorTest {
     for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {
       assertNotNull(SupportedLanguages.JAVA.getExtension(gradleSourceSet));
       assertNull(SupportedLanguages.SCALA.getExtension(gradleSourceSet));
+      assertNull(SupportedLanguages.KOTLIN.getExtension(gradleSourceSet));
       assertEquals("junit5-jupiter-starter-gradle", gradleSourceSet.getProjectName());
       assertEquals(":", gradleSourceSet.getProjectPath());
       assertEquals(projectDir, gradleSourceSet.getProjectDir());
@@ -328,5 +330,25 @@ class GradleApiConnectorTest {
       assertEquals(StatusCode.ERROR, failingTest);
       return null;
     });
+  }
+
+  @Test
+  void testGetGradleHasKotlin() {
+    File projectDir = projectPath.resolve("kotlin").toFile();
+    GradleSourceSets gradleSourceSets = getGradleSourceSets(projectDir);
+    assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
+    GradleSourceSet main = findSourceSet(gradleSourceSets, "kotlin [main]");
+    KotlinExtension kotlinExtension = SupportedLanguages.KOTLIN.getExtension(main);
+    assertNotNull(kotlinExtension);
+    assertEquals("1.2", kotlinExtension.getKotlinApiVersion());
+    assertEquals("1.3", kotlinExtension.getKotlinLanguageVersion());
+    assertFalse(main.getCompileClasspath().isEmpty());
+    assertTrue(main.getCompileClasspath().stream().anyMatch(
+            file -> file.getName().equals("kotlin-stdlib-1.9.21.jar")));
+    assertFalse(kotlinExtension.getKotlincOptions().isEmpty());
+    assertTrue(kotlinExtension.getKotlincOptions().stream()
+            .anyMatch(arg -> arg.equals("-opt-in=org.mylibrary.OptInAnnotation")));
+
+    // TODO test getKotlinAssociates
   }
 }

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -26,6 +26,7 @@ import ch.epfl.scala.bsp4j.JvmBuildTarget;
 import ch.epfl.scala.bsp4j.ScalaBuildTarget;
 import ch.epfl.scala.bsp4j.ScalacOptionsParams;
 import ch.epfl.scala.bsp4j.ScalacOptionsResult;
+import ch.epfl.scala.bsp4j.extended.KotlinBuildTarget;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -116,6 +117,28 @@ class BuildTargetServiceTest {
     assertEquals("foo/bar", response.getTargets().get(0).getBaseDirectory());
     assertEquals("scala", response.getTargets().get(0).getDataKind());
     assertInstanceOf(ScalaBuildTarget.class, response.getTargets().get(0).getData());
+  }
+
+  @Test
+  void testWorkspaceKotlinBuildTargets() {
+    BuildTarget target = mock(BuildTarget.class);
+    when(target.getBaseDirectory()).thenReturn("foo/bar");
+    when(target.getDataKind()).thenReturn("kotlin");
+    when(target.getData()).thenReturn(new KotlinBuildTarget(null, null, null, null, null));
+    GradleBuildTarget gradleBuildTarget = new GradleBuildTarget(target,
+            mock(GradleSourceSet.class));
+    when(buildTargetManager.getAllGradleBuildTargets())
+            .thenReturn(Arrays.asList(gradleBuildTarget));
+
+    BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
+            connector, preferenceManager);
+
+    WorkspaceBuildTargetsResult response = buildTargetService.getWorkspaceBuildTargets();
+
+    assertEquals(1, response.getTargets().size());
+    assertEquals("foo/bar", response.getTargets().get(0).getBaseDirectory());
+    assertEquals("kotlin", response.getTargets().get(0).getDataKind());
+    assertInstanceOf(KotlinBuildTarget.class, response.getTargets().get(0).getData());
   }
 
   @Test

--- a/testProjects/kotlin/build.gradle
+++ b/testProjects/kotlin/build.gradle
@@ -1,0 +1,27 @@
+buildscript {
+    repositories { mavenCentral() }
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.21")
+    }
+}
+
+// must be defined to resolve org.jetbrains.kotlin:kotlin-stdlib
+repositories {
+  mavenCentral()
+}
+
+apply plugin: 'kotlin'
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_9
+  kotlinOptions {
+    jvmTarget = "1.8"
+    apiVersion = "1.2"
+    languageVersion = "1.3"
+  }
+  // TODO how to set associates?
+  compilerOptions {
+        freeCompilerArgs.add("-opt-in=org.mylibrary.OptInAnnotation")
+    }
+}

--- a/testProjects/kotlin/settings.gradle
+++ b/testProjects/kotlin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'kotlin'


### PR DESCRIPTION
Adds Kotlin support.

I don't use Kotlin but I thought it would be good to get support for a few languages to help decide on best design for handling multiple languages.

BSP spec is not finalised for Kotlin.  See [here](https://github.com/build-server-protocol/build-server-protocol/issues/520).  I've no idea about how to setup `associates` in a Gradle build so I've ignored it.

Kotlin plugin doesn't seem to be part of Gradle so everything here is done with reflection - I guess you could add the Kotlin library into the `plugin` project if you don't want to use reflection.

Up to you if you want to merge. I could change this to a draft PR.