### PR TITLE
Handle composite builds

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleIncludedBuild.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleIncludedBuild.java
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model;
+
+import java.io.File;
+import java.io.Serializable;
+
+/**
+ * Represents a source set in a Gradle project.
+ */
+public interface GradleIncludedBuild extends Serializable {
+
+  /**
+   * Equivalent to {@code org.gradle.api.initialization.IncludedBuild.getName()}. 
+   */
+  public String getName();
+
+  /**
+   * Equivalent to {@code org.gradle.api.initialization.IncludedBuild.getProjectDir()}. 
+   */
+  public File getProjectDir();
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSets.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSets.java
@@ -10,5 +10,7 @@ import java.util.List;
  * List of all Gradle source set instances.
  */
 public interface GradleSourceSets extends Serializable {
+  public List<GradleIncludedBuild> getGradleIncludedBuilds();
+
   public List<GradleSourceSet> getGradleSourceSets();
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleIncludedBuild.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleIncludedBuild.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model.impl;
+
+import java.io.File;
+import java.util.Objects;
+
+import com.microsoft.java.bs.gradle.model.GradleIncludedBuild;
+
+/**
+ * Default implementation of {@link GradleIncludedBuild}.
+ */
+public class DefaultGradleIncludedBuild implements GradleIncludedBuild {
+  private static final long serialVersionUID = 1L;
+
+  private String name;
+
+  private File projectDir;
+
+  public DefaultGradleIncludedBuild() {}
+
+  public DefaultGradleIncludedBuild(String name, File projectDir) {
+    this.name = name;
+    this.projectDir = projectDir;
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param gradleIncludedBuild the included build set to copy from.
+   */
+  public DefaultGradleIncludedBuild(GradleIncludedBuild gradleIncludedBuild) {
+    this(gradleIncludedBuild.getName(), gradleIncludedBuild.getProjectDir());
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public File getProjectDir() {
+    return projectDir;
+  }
+
+  public void setProjectDir(File projectDir) {
+    this.projectDir = projectDir;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, projectDir);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    DefaultGradleIncludedBuild other = (DefaultGradleIncludedBuild) obj;
+    return Objects.equals(name, other.name)
+        && Objects.equals(projectDir, other.projectDir);
+  }
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSets.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSets.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.microsoft.java.bs.gradle.model.GradleIncludedBuild;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
 
@@ -16,9 +17,13 @@ import com.microsoft.java.bs.gradle.model.GradleSourceSets;
 public class DefaultGradleSourceSets implements GradleSourceSets {
   private static final long serialVersionUID = 1L;
 
+  private List<GradleIncludedBuild> gradleIncludedBuilds;
+
   private List<GradleSourceSet> gradleSourceSets;
 
-  public DefaultGradleSourceSets(List<GradleSourceSet> gradleSourceSets) {
+  public DefaultGradleSourceSets(List<GradleIncludedBuild> gradleIncludedBuilds,
+      List<GradleSourceSet> gradleSourceSets) {
+    this.gradleIncludedBuilds = gradleIncludedBuilds;
     this.gradleSourceSets = gradleSourceSets;
   }
 
@@ -26,10 +31,22 @@ public class DefaultGradleSourceSets implements GradleSourceSets {
    * Copy constructor.
    */
   public DefaultGradleSourceSets(GradleSourceSets sourceSets) {
-    this.gradleSourceSets = sourceSets.getGradleSourceSets().stream()
-        .map(DefaultGradleSourceSet::new).collect(Collectors.toList());
+    this(sourceSets.getGradleIncludedBuilds().stream()
+        .map(DefaultGradleIncludedBuild::new).collect(Collectors.toList()),
+         sourceSets.getGradleSourceSets().stream()
+        .map(DefaultGradleSourceSet::new).collect(Collectors.toList()));
   }
 
+  @Override
+  public List<GradleIncludedBuild> getGradleIncludedBuilds() {
+    return gradleIncludedBuilds;
+  }
+
+  public void setGradleIncludedBuilds(List<GradleIncludedBuild> gradleIncludedBuilds) {
+    this.gradleIncludedBuilds = gradleIncludedBuilds;
+  }
+
+  @Override
   public List<GradleSourceSet> getGradleSourceSets() {
     return gradleSourceSets;
   }
@@ -40,7 +57,7 @@ public class DefaultGradleSourceSets implements GradleSourceSets {
 
   @Override
   public int hashCode() {
-    return Objects.hash(gradleSourceSets);
+    return Objects.hash(gradleIncludedBuilds, gradleSourceSets);
   }
 
   @Override
@@ -55,6 +72,7 @@ public class DefaultGradleSourceSets implements GradleSourceSets {
       return false;
     }
     DefaultGradleSourceSets other = (DefaultGradleSourceSets) obj;
-    return Objects.equals(gradleSourceSets, other.gradleSourceSets);
+    return Objects.equals(gradleIncludedBuilds, other.gradleIncludedBuilds)
+        && Objects.equals(gradleSourceSets, other.gradleSourceSets);
   }
 }

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -6,18 +6,21 @@ package com.microsoft.java.bs.gradle.plugin;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
@@ -28,12 +31,14 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 import org.gradle.util.GradleVersion;
 
+import com.microsoft.java.bs.gradle.model.GradleIncludedBuild;
 import com.microsoft.java.bs.gradle.model.BuildTargetDependency;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
-import com.microsoft.java.bs.gradle.model.LanguageExtension;
+import com.microsoft.java.bs.gradle.model.impl.DefaultGradleIncludedBuild;
 import com.microsoft.java.bs.gradle.model.impl.DefaultBuildTargetDependency;
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSet;
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSets;
+import com.microsoft.java.bs.gradle.model.LanguageExtension;
 import com.microsoft.java.bs.gradle.plugin.dependency.DependencyCollector;
 
 /**
@@ -48,12 +53,21 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
   @Override
   public Object buildAll(String modelName, Project rootProject) {
     Set<Project> allProject = rootProject.getAllprojects();
+    List<GradleIncludedBuild> includedBuilds = new ArrayList<>();
     SourceSetCache cache = new SourceSetCache();
     // this set is used to eliminate the source, resource and output
     // directories from the module dependencies.
     Set<File> exclusionFromDependencies = new HashSet<>();
     // mapping Gradle source set to our customized model.
     for (Project project : allProject) {
+      // lookup included builds regardless of sourcesets existing
+      Gradle gradle = project.getGradle();
+      includedBuilds.addAll(
+          gradle.getIncludedBuilds()
+          .stream().map(includedBuild ->
+            new DefaultGradleIncludedBuild(includedBuild.getName(), includedBuild.getProjectDir()))
+          .collect(Collectors.toList()));
+
       SourceSetContainer sourceSets = getSourceSetContainer(project);
       if (sourceSets == null || sourceSets.isEmpty()) {
         continue;
@@ -159,7 +173,8 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
 
     }
 
-    return new DefaultGradleSourceSets(new LinkedList<>(cache.getAllGradleSourceSets()));
+    return new DefaultGradleSourceSets(includedBuilds,
+        new LinkedList<>(cache.getAllGradleSourceSets()));
   }
 
   private void setModuleDependencies(SourceSetCache cache, Set<File> exclusionFromDependencies) {

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -123,6 +123,20 @@ class GradleApiConnectorTest {
     assertFalse(findSourceSet(gradleSourceSets, "test-tag [testFixtures]").hasTests());
   }
 
+  @Test
+  void testCompositeBuild() {
+    File projectDir = projectPath.resolve("composite-build").toFile();
+    PreferenceManager preferenceManager = new PreferenceManager();
+    preferenceManager.setPreferences(new Preferences());
+    GradleApiConnector connector = new GradleApiConnector(preferenceManager);
+    GradleSourceSets gradleSourceSets = connector.getGradleSourceSets(projectDir.toURI());
+    assertEquals(4, gradleSourceSets.getGradleSourceSets().size());
+    findSourceSet(gradleSourceSets, "projectA [main]");
+    findSourceSet(gradleSourceSets, "projectA [test]");
+    findSourceSet(gradleSourceSets, "projectB [main]");
+    findSourceSet(gradleSourceSets, "projectB [test]");
+  }
+
   private void assertHasBuildTargetDependency(GradleSourceSet sourceSet,
       GradleSourceSet dependency) {
     boolean exists = sourceSet.getBuildTargetDependencies().stream()

--- a/testProjects/composite-build/projectA/build.gradle
+++ b/testProjects/composite-build/projectA/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+	id 'java'
+}

--- a/testProjects/composite-build/projectA/settings.gradle
+++ b/testProjects/composite-build/projectA/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'projectA'

--- a/testProjects/composite-build/projectB/build.gradle
+++ b/testProjects/composite-build/projectB/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+	id 'java'
+}

--- a/testProjects/composite-build/projectB/settings.gradle
+++ b/testProjects/composite-build/projectB/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'projectB'

--- a/testProjects/composite-build/settings.gradle
+++ b/testProjects/composite-build/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'composite-build'
+
+includeBuild 'projectA'
+includeBuild 'projectB'


### PR DESCRIPTION
This PR extracts source sets for composite builds - previously, included builds would be ignored.

I've had to get rid of the unique display name code and go with `project [sourceset]` for all target display names.  It just gets far too complicated for little reward when composite builds are added into the mix.

Composite builds have to be handled in the `GradleAPIConnector` as each included build requires a new `ProjectConnection`

