### PR TITLE
Support running main classes, tests and test discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Following BSP requests are supported in the current implementation:
 - `buildTarget/cleanCache`
 - `buildTarget/javacOptions`
 - `buildTarget/scalacOptions`
+- `buildTarget/jvmTestEnvironment`
+- `buildTarget/run`
+- `buildTarget/test`
 - `workspace/buildTargets`
 - `workspace/reload`
 

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
@@ -111,6 +111,11 @@ public interface GradleSourceSet extends Serializable {
   public boolean hasTests();
 
   /**
+   * list of test tasks that are associated with this source set.
+   */
+  public Set<GradleTestTask> getTestTasks();
+
+  /**
    * Extensions of the source set.
    */
   public Map<String, LanguageExtension> getExtensions();

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleTestTask.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleTestTask.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Contains test information relating to a Gradle Test task.
+ */
+public interface GradleTestTask extends Serializable {
+
+  String getTaskPath();
+
+  List<File> getClasspath();
+
+  List<String> getJvmOptions();
+
+  File getWorkingDirectory();
+
+  Map<String, String> getEnvironmentVariables();
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
 import com.microsoft.java.bs.gradle.model.BuildTargetDependency;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
+import com.microsoft.java.bs.gradle.model.GradleTestTask;
 import com.microsoft.java.bs.gradle.model.LanguageExtension;
 
 /**
@@ -57,7 +58,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   private Set<BuildTargetDependency> buildTargetDependencies;
 
-  private boolean hasTests;
+  private Set<GradleTestTask> testTasks;
 
   private Map<String, LanguageExtension> extensions;
 
@@ -89,7 +90,8 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         .map(DefaultGradleModuleDependency::new).collect(Collectors.toSet());
     this.buildTargetDependencies = gradleSourceSet.getBuildTargetDependencies().stream()
         .map(DefaultBuildTargetDependency::new).collect(Collectors.toSet());
-    this.hasTests = gradleSourceSet.hasTests();
+    this.testTasks = gradleSourceSet.getTestTasks().stream()
+        .map(DefaultGradleTestTask::new).collect(Collectors.toSet());
     this.extensions = gradleSourceSet.getExtensions().entrySet().stream()
       .collect(Collectors.toMap(Map.Entry::getKey,
         e -> convertLanguageExtension(e.getValue())));
@@ -260,11 +262,16 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   @Override
   public boolean hasTests() {
-    return hasTests;
+    return testTasks != null && testTasks.size() > 0;
   }
 
-  public void setHasTests(boolean hasTests) {
-    this.hasTests = hasTests;
+  @Override
+  public Set<GradleTestTask> getTestTasks() {
+    return testTasks;
+  }
+
+  public void setTestTasks(Set<GradleTestTask> testTasks) {
+    this.testTasks = testTasks;
   }
 
   @Override
@@ -282,7 +289,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         projectDir, rootDir, sourceSetName, classesTaskName, cleanTaskName, taskNames, sourceDirs,
         generatedSourceDirs, sourceOutputDir, resourceDirs, resourceOutputDir,
         compileClasspath, moduleDependencies, buildTargetDependencies,
-        hasTests, extensions);
+        testTasks, extensions);
   }
 
   @Override
@@ -315,7 +322,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         && Objects.equals(compileClasspath, other.compileClasspath)
         && Objects.equals(moduleDependencies, other.moduleDependencies)
         && Objects.equals(buildTargetDependencies, other.buildTargetDependencies)
-        && hasTests == other.hasTests
+        && Objects.equals(testTasks, other.testTasks)
         && Objects.equals(extensions, other.extensions);
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleTestTask.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleTestTask.java
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model.impl;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.microsoft.java.bs.gradle.model.GradleTestTask;
+
+/**
+ * Contains test information relating to a Gradle Test task.
+ */
+public class DefaultGradleTestTask implements GradleTestTask {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String taskPath;
+  private final List<File> classpath;
+  private final List<String> jvmOptions;
+  private final File workingDirectory;
+  private final Map<String, String> environmentVariables;
+
+  /**
+   * Initialize the test information.
+   */
+  public DefaultGradleTestTask(String taskPath, List<File> classpath,
+      List<String> jvmOptions, File workingDirectory,
+      Map<String, String> environmentVariables) {
+    this.taskPath = taskPath;
+    this.classpath = classpath;
+    this.jvmOptions = jvmOptions;
+    this.workingDirectory = workingDirectory;
+    this.environmentVariables = environmentVariables;
+  }
+
+  /**
+   * copy constructor.
+   */
+  public DefaultGradleTestTask(GradleTestTask gradleTestTask) {
+    this.taskPath = gradleTestTask.getTaskPath();
+    this.classpath = gradleTestTask.getClasspath();
+    this.jvmOptions = gradleTestTask.getJvmOptions();
+    this.workingDirectory = gradleTestTask.getWorkingDirectory();
+    this.environmentVariables = gradleTestTask.getEnvironmentVariables();
+  }
+
+  @Override
+  public String getTaskPath() {
+    return taskPath;
+  }
+
+  @Override
+  public List<File> getClasspath() {
+    return classpath;
+  }
+
+  @Override
+  public List<String> getJvmOptions() {
+    return jvmOptions;
+  }
+
+  @Override
+  public File getWorkingDirectory() {
+    return workingDirectory;
+  }
+
+  @Override
+  public Map<String, String> getEnvironmentVariables() {
+    return environmentVariables;
+  }
+  
+  @Override
+  public int hashCode() {
+    return Objects.hash(taskPath, classpath, jvmOptions, workingDirectory,
+        environmentVariables);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    DefaultGradleTestTask other = (DefaultGradleTestTask) obj;
+    return Objects.equals(taskPath, other.taskPath)
+        && Objects.equals(classpath, other.classpath)
+        && Objects.equals(jvmOptions, other.jvmOptions)
+        && Objects.equals(workingDirectory, other.workingDirectory)
+        && Objects.equals(environmentVariables, other.environmentVariables);
+  }
+}

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -12,6 +12,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -31,10 +32,12 @@ import org.gradle.util.GradleVersion;
 
 import com.microsoft.java.bs.gradle.model.BuildTargetDependency;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
+import com.microsoft.java.bs.gradle.model.GradleTestTask;
 import com.microsoft.java.bs.gradle.model.LanguageExtension;
 import com.microsoft.java.bs.gradle.model.impl.DefaultBuildTargetDependency;
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSet;
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSets;
+import com.microsoft.java.bs.gradle.model.impl.DefaultGradleTestTask;
 import com.microsoft.java.bs.gradle.plugin.dependency.DependencyCollector;
 
 /**
@@ -76,9 +79,6 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
         gradleSourceSet.setCleanTaskName(cleanTaskName);
         Set<String> taskNames = new HashSet<>();
         gradleSourceSet.setTaskNames(taskNames);
-        taskNames.add(classesTaskName);
-        taskNames.add(cleanTaskName);
-        taskNames.add(getFullTaskName(projectPath, sourceSet.getProcessResourcesTaskName()));
         String projectName = stripPathPrefix(gradleSourceSet.getProjectPath());
         if (projectName == null || projectName.length() == 0) {
           projectName = gradleSourceSet.getProjectName();
@@ -131,16 +131,27 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
         }
 
         // tests
+        Set<GradleTestTask> testTasks = new HashSet<>();
         if (sourceOutputDir != null) {
-          TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
-          for (Test testTask : testTasks) {
-            FileCollection files = testTask.getTestClassesDirs();
+          TaskCollection<Test> tasks = project.getTasks().withType(Test.class);
+          for (Test task : tasks) {
+            FileCollection files = task.getTestClassesDirs();
             if (files.contains(sourceOutputDir)) {
-              gradleSourceSet.setHasTests(true);
-              break;
+              String taskPath = task.getPath();
+              List<File> classpath = new LinkedList<>(task.getClasspath().getFiles());
+              List<String> jvmOptions = task.getAllJvmArgs();
+              File workingDirectory = task.getWorkingDir();
+              Map<String, String> environmentVariables = task.getEnvironment().entrySet()
+                  .stream()
+                  .collect(Collectors.toMap(Map.Entry::getKey, Object::toString));
+              GradleTestTask testTask = new DefaultGradleTestTask(taskPath, classpath,
+                  jvmOptions, workingDirectory, environmentVariables);
+              testTasks.add(testTask);
             }
           }
         }
+        
+        gradleSourceSet.setTestTasks(testTasks);
       });
     }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':model')
-    implementation 'org.gradle:gradle-tooling-api:8.1.1'
+    implementation 'org.gradle:gradle-tooling-api:8.7'
     implementation 'ch.epfl.scala:bsp4j:2.1.0-M4'
     implementation 'org.apache.commons:commons-lang3:3.13.0'
 

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
@@ -10,24 +10,38 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.gradle.tooling.BuildException;
 import org.gradle.tooling.BuildLauncher;
 import org.gradle.tooling.GradleConnectionException;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ModelBuilder;
 import org.gradle.tooling.ProjectConnection;
+import org.gradle.tooling.TestLauncher;
 import org.gradle.tooling.events.OperationType;
 import org.gradle.tooling.model.build.BuildEnvironment;
+import org.gradle.util.GradleVersion;
 
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
+import com.microsoft.java.bs.core.internal.model.GradleTestEntity;
+import com.microsoft.java.bs.core.internal.reporter.AppRunReporter;
+import com.microsoft.java.bs.core.internal.reporter.CompileProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.DefaultProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.ProgressReporter;
+import com.microsoft.java.bs.core.internal.reporter.TestNameRecorder;
+import com.microsoft.java.bs.core.internal.reporter.TestReportReporter;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
+import com.microsoft.java.bs.gradle.model.GradleTestTask;
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSets;
 
 import ch.epfl.scala.bsp4j.BuildClient;
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.StatusCode;
 
 /**
@@ -47,15 +61,19 @@ public class GradleApiConnector {
    */
   public String getGradleVersion(URI projectUri) {
     try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
-      BuildEnvironment model = connection
-          .model(BuildEnvironment.class)
-          .withArguments("--no-daemon")
-          .get();
-      return model.getGradle().getGradleVersion();
+      return getGradleVersion(connection);
     } catch (BuildException e) {
       LOGGER.severe("Failed to get Gradle version: " + e.getMessage());
       return "";
     }
+  }
+
+  private String getGradleVersion(ProjectConnection connection) {
+    BuildEnvironment model = connection
+        .model(BuildEnvironment.class)
+        .withArguments("--no-daemon")
+        .get();
+    return model.getGradle().getGradleVersion();
   }
 
   /**
@@ -132,6 +150,167 @@ public class GradleApiConnector {
         summary += "\n" + errorOut;
       }
       reporter.sendError(summary);
+      statusCode = StatusCode.ERROR;
+    }
+
+    return statusCode;
+  }
+
+  /**
+   * request Gradle to return test classes.
+   */
+  public Map<BuildTargetIdentifier, List<GradleTestEntity>> getTestClasses(URI projectUri,
+      Map<BuildTargetIdentifier, Set<GradleTestTask>> testTaskMap, BuildClient client,
+      CompileProgressReporter compileProgressReporter) {
+ 
+    Map<BuildTargetIdentifier, List<GradleTestEntity>> results = new HashMap<>();
+    DefaultProgressReporter reporter = new DefaultProgressReporter(client);
+
+    try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
+      String gradleVersion = getGradleVersion(connection);
+      // use --test-dry-run to discover tests.  Gradle version must be 8.3 or higher.
+      if (GradleVersion.version(gradleVersion).compareTo(GradleVersion.version("8.3")) < 0) {
+        reporter.sendError("Error searching for test classes: Gradle version "
+            + gradleVersion + " must be >= 8.3");
+      } else {
+        for (Map.Entry<BuildTargetIdentifier, Set<GradleTestTask>> entry :
+            testTaskMap.entrySet()) {
+          List<GradleTestEntity> gradleTestEntities = new LinkedList<>();
+          for (GradleTestTask gradleTestTask : entry.getValue()) {
+            // can't pass arguments to tasks e.g. "--test-dry-run"
+            // so manipulate test task using init script.
+            File initScript = Utils.createInitScriptFile("gradle.projectsLoaded {"
+                + "   rootProject {"
+                + "    tasks.getByPath('" + gradleTestTask.getTaskPath() + "')?.setDryRun(true)"
+                + "   }"
+                + " }");
+            try {
+              TestNameRecorder testNameRecorder = new TestNameRecorder();
+              try {
+
+                TestLauncher launcher = Utils
+                    .getTestLauncher(connection, preferenceManager.getPreferences())
+                    .forTasks(gradleTestTask.getTaskPath())
+                    .addArguments("--init-script", initScript.getAbsolutePath())
+                    .addProgressListener(testNameRecorder, OperationType.TEST)
+                    .addProgressListener(reporter, OperationType.TASK);
+                if (compileProgressReporter != null) {
+                  launcher.addProgressListener(compileProgressReporter, OperationType.TASK);
+                }
+                launcher.run();
+              } catch (GradleConnectionException | IllegalStateException e) {
+                String message = String.join("\n", ExceptionUtils.getRootCauseStackTraceList(e));
+                reporter.sendError("Error searching for test classes in " 
+                    + gradleTestTask.getTaskPath() + " " + message);
+              }
+              Set<String> mainClasses = testNameRecorder.getMainClasses();
+              GradleTestEntity gradleTestEntity = new GradleTestEntity(gradleTestTask, mainClasses);
+              gradleTestEntities.add(gradleTestEntity);
+            } finally {
+              initScript.delete();
+            }
+          }
+
+          results.put(entry.getKey(), gradleTestEntities);
+        }
+      }
+    } catch (GradleConnectionException | IllegalStateException e) {
+      reporter.sendError("Error searching for test classes: " + e.getMessage());
+    }
+
+    return results;
+  }
+
+  /**
+   * request Gradle to run test classes.
+   */
+  public StatusCode runTestClasses(URI projectUri,
+      Map<BuildTargetIdentifier, Set<String>> testClassesMap,
+      BuildClient client, String originId,
+      CompileProgressReporter compileProgressReporter) {
+
+    StatusCode statusCode = StatusCode.OK;
+    ProgressReporter reporter = new DefaultProgressReporter(client);
+    try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
+      for (Map.Entry<BuildTargetIdentifier, Set<String>> entry : testClassesMap.entrySet()) {
+        TestReportReporter testReportReporter = new TestReportReporter(entry.getKey(),
+            client, originId);
+        try {
+          TestLauncher launcher = Utils
+              .getTestLauncher(connection, preferenceManager.getPreferences())
+              .withJvmTestClasses(entry.getValue())
+              .addProgressListener(testReportReporter, OperationType.TEST);
+          if (compileProgressReporter != null) {
+            launcher.addProgressListener(compileProgressReporter, OperationType.TASK);
+          }
+          launcher.run();
+        } catch (GradleConnectionException | IllegalStateException e) {
+          testReportReporter.addException(e);
+          statusCode = StatusCode.ERROR;
+        } finally {
+          testReportReporter.sendResult();
+        }
+      }
+    } catch (GradleConnectionException | IllegalStateException e) {
+      reporter.sendError("Error running test classes: " + e.getMessage());
+      statusCode = StatusCode.ERROR;
+    }
+
+    return statusCode;
+  }
+
+  /**
+   * request Gradle to run main class.
+   */
+  public StatusCode runMainClass(URI projectUri, String projectPath, String sourceSetName,
+      String className, Map<String, String> environmentVariables, List<String> jvmOptions,
+      List<String> arguments, BuildClient client,
+      CompileProgressReporter compileProgressReporter) {
+
+    StatusCode statusCode = StatusCode.OK;
+    String taskName = "buildServerRunApp";
+    ProgressReporter reporter = new AppRunReporter(client, taskName);
+    try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
+      String execTask = "gradle.projectsEvaluated {\n"
+          + "  def proj = rootProject.findProject('" + projectPath + "')\n"
+          + "  if (proj != null) {\n"
+          + "    proj.getTasks().create('" + taskName + "', JavaExec.class, {\n"
+          + "      classpath = proj.sourceSets." + sourceSetName + ".runtimeClasspath\n"
+          + "      mainClass = '" + className + "'\n";
+      if (arguments != null && !arguments.isEmpty()) {
+        String args = arguments.stream().collect(Collectors.joining("','", "['", "']"));
+        execTask += "      args = " + args + "\n";
+      }
+      if (environmentVariables != null && !environmentVariables.isEmpty()) {
+        String envVars = environmentVariables.entrySet().stream()
+            .map(entry -> "'" + entry.getKey() + "':'" + entry.getValue() + "'")
+            .collect(Collectors.joining(",", "[", "]"));
+        execTask += "      environment = " + envVars + "\n";
+      }
+      if (jvmOptions != null && !jvmOptions.isEmpty()) {
+        String jvmArgs = jvmOptions.stream().collect(Collectors.joining("','", "['", "']"));
+        execTask += "      jvmArgs = " + jvmArgs + "\n";
+      }
+      execTask += "    })\n"
+           + "  }\n"
+           + "}\n";
+      File initScript = Utils.createInitScriptFile(execTask);
+      try {
+        BuildLauncher launcher = Utils
+            .getBuildLauncher(connection, preferenceManager.getPreferences())
+            .forTasks(taskName)
+            .addArguments("--init-script", initScript.getAbsolutePath())
+            .addProgressListener(reporter, OperationType.TASK);
+        if (compileProgressReporter != null) {
+          launcher.addProgressListener(compileProgressReporter, OperationType.TASK);
+        }
+        launcher.run();
+      } finally {
+        initScript.delete();
+      }
+    } catch (GradleConnectionException | IllegalStateException e) {
+      String message = String.join("\n", ExceptionUtils.getRootCauseStackTraceList(e));
+      reporter.sendError("Error running main class: " + message);
       statusCode = StatusCode.ERROR;
     }
 

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
@@ -5,7 +5,9 @@ package com.microsoft.java.bs.core.internal.gradle;
 
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -13,9 +15,11 @@ import java.util.Optional;
 
 import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils;
 import org.gradle.tooling.BuildLauncher;
+import org.gradle.tooling.ConfigurableLauncher;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ModelBuilder;
 import org.gradle.tooling.ProjectConnection;
+import org.gradle.tooling.TestLauncher;
 import org.gradle.util.GradleVersion;
 
 import com.microsoft.java.bs.core.Launcher;
@@ -90,23 +94,7 @@ public class Utils {
    */
   public static <T> ModelBuilder<T> getModelBuilder(ProjectConnection connection,
       Preferences preferences, Class<T> clazz) {
-    ModelBuilder<T> modelBuilder = connection.model(clazz);
-
-    File gradleJavaHomeFile = getGradleJavaHomeFile(preferences.getGradleJavaHome());
-    if (gradleJavaHomeFile != null && gradleJavaHomeFile.exists()) {
-      modelBuilder.setJavaHome(gradleJavaHomeFile);
-    }
-
-    List<String> gradleJvmArguments = preferences.getGradleJvmArguments();
-    if (gradleJvmArguments != null && !gradleJvmArguments.isEmpty()) {
-      modelBuilder.setJvmArguments(gradleJvmArguments);
-    }
-
-    List<String> gradleArguments = preferences.getGradleArguments();
-    if (gradleArguments != null && !gradleArguments.isEmpty()) {
-      modelBuilder.withArguments(gradleArguments);
-    }
-    return modelBuilder;
+    return setLauncherProperties(connection.model(clazz), preferences);
   }
 
   /**
@@ -117,7 +105,28 @@ public class Utils {
    */
   public static BuildLauncher getBuildLauncher(ProjectConnection connection,
       Preferences preferences) {
-    BuildLauncher launcher = connection.newBuild();
+    return setLauncherProperties(connection.newBuild(), preferences);
+  }
+
+  /**
+   * Get the Test Launcher.
+   *
+   * @param connection The project connection.
+   * @param preferences The preferences.
+   */
+  public static TestLauncher getTestLauncher(ProjectConnection connection,
+      Preferences preferences) {
+    return setLauncherProperties(connection.newTestLauncher(), preferences);
+  }
+  
+  /**
+   * Set the Launcher properties.
+   *
+   * @param launcher The launcher.
+   * @param preferences The preferences.
+   */
+  public static <T extends ConfigurableLauncher<T>> T setLauncherProperties(T launcher,
+      Preferences preferences) {
 
     File gradleJavaHomeFile = getGradleJavaHomeFile(preferences.getGradleJavaHome());
     if (gradleJavaHomeFile != null && gradleJavaHomeFile.exists()) {
@@ -290,5 +299,25 @@ public class Utils {
     }
 
     return GradleBuildKind.TAPI;
+  }
+
+  /**
+   * Create a temporary init.gradle script.
+   * Caller is responsible for file deletion.
+   *
+   * @param contents contents of script.
+   * @return the init.gradle file.
+   */
+  public static File createInitScriptFile(String contents) {
+    try {
+      File initScriptFile = File.createTempFile("init", ".gradle");
+      if (!initScriptFile.getParentFile().exists()) {
+        initScriptFile.getParentFile().mkdirs();
+      }
+      Files.write(initScriptFile.toPath(), contents.getBytes());
+      return initScriptFile;
+    } catch (IOException e) {
+      throw new IllegalStateException("Error creating init file", e);
+    }
   }
 }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
@@ -58,17 +58,16 @@ public class BuildTargetManager {
       List<String> tags = getBuildTargetTags(sourceSet.hasTests());
       BuildTargetIdentifier btId = new BuildTargetIdentifier(uri.toString());
       List<String> languages = new LinkedList<>(sourceSet.getExtensions().keySet());
+      BuildTargetCapabilities buildTargetCapabilities = new BuildTargetCapabilities();
+      buildTargetCapabilities.setCanCompile(true);
+      buildTargetCapabilities.setCanRun(true);
+      buildTargetCapabilities.setCanTest(true);
       BuildTarget bt = new BuildTarget(
           btId,
           tags,
           languages,
           Collections.emptyList(),
-          new BuildTargetCapabilities(
-            true /* canCompile */,
-            false /* canTest */,
-            false /* canRun */,
-            false /* canDebug */
-          )
+          buildTargetCapabilities
       );
       bt.setBaseDirectory(sourceSet.getRootDir().toURI().toString());
       bt.setDisplayName(sourceSet.getDisplayName());

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/model/GradleTestEntity.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/model/GradleTestEntity.java
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.core.internal.model;
+
+import java.util.Set;
+import java.util.Objects;
+
+import com.microsoft.java.bs.gradle.model.GradleTestTask;
+
+/**
+ * Contains test information relating to a Gradle Test task.
+ * And the test classes 
+ */
+public class GradleTestEntity {
+
+  private final GradleTestTask gradleTestTask;
+  private final Set<String> testClasses;
+
+  /**
+   * Initialize the test information.
+   */
+  public GradleTestEntity(GradleTestTask gradleTestTask, Set<String> testClasses) {
+    this.gradleTestTask = gradleTestTask;
+    this.testClasses = testClasses;
+  }
+
+  public GradleTestTask getGradleTestTask() {
+    return gradleTestTask;
+  }
+
+  public Set<String> getTestClasses() {
+    return testClasses;
+  }
+  
+  @Override
+  public int hashCode() {
+    return Objects.hash(gradleTestTask, testClasses);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    GradleTestEntity other = (GradleTestEntity) obj;
+    return Objects.equals(gradleTestTask, other.gradleTestTask)
+        && Objects.equals(testClasses, other.testClasses);
+  }
+}

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/AppRunReporter.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/AppRunReporter.java
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.core.internal.reporter;
+
+import org.gradle.tooling.events.FailureResult;
+import org.gradle.tooling.events.FinishEvent;
+import org.gradle.tooling.events.OperationResult;
+import org.gradle.tooling.events.ProgressEvent;
+import org.gradle.tooling.events.StartEvent;
+
+import ch.epfl.scala.bsp4j.BuildClient;
+import ch.epfl.scala.bsp4j.StatusCode;
+import ch.epfl.scala.bsp4j.TaskFinishParams;
+import ch.epfl.scala.bsp4j.TaskId;
+import ch.epfl.scala.bsp4j.TaskProgressParams;
+import ch.epfl.scala.bsp4j.TaskStartParams;
+
+/**
+ * A default implementation of {@link ProgressReporter}.
+ */
+public class AppRunReporter extends ProgressReporter {
+
+  private final String taskName;
+
+  /**
+   * Instantiates a {@link AppRunReporter}.
+   *
+   * @param client BSP client to report to.
+   * @param taskName the name of the task that runs the app.
+   */
+  public AppRunReporter(BuildClient client, String taskName) {
+    super(client, null);
+    this.taskName = taskName;
+  }
+
+  @Override
+  public void statusChanged(ProgressEvent event) {
+    if (client != null) {
+      if (event.toString().contains(taskName)) {
+        String taskPath = getTaskPath(event.getDescriptor());
+        TaskId taskId = getTaskId(taskPath);
+        if (event instanceof StartEvent) {
+          taskStarted(taskId, event.getDisplayName());
+        } else if (event instanceof FinishEvent) {
+          OperationResult result = ((FinishEvent) event).getResult();
+          StatusCode status = result instanceof FailureResult ? StatusCode.ERROR : StatusCode.OK;
+          taskFinished(taskId, event.getDisplayName(), status);
+        } else {
+          taskInProgress(taskId, event.getDisplayName());
+        }
+      }
+    }
+  }
+
+  private void taskStarted(TaskId taskId, String message) {
+    TaskStartParams startParam = new TaskStartParams(taskId);
+    startParam.setEventTime(System.currentTimeMillis());
+    startParam.setMessage(message);
+    client.onBuildTaskStart(startParam);
+  }
+
+  private void taskInProgress(TaskId taskId, String message) {
+    TaskProgressParams progressParam = new TaskProgressParams(taskId);
+    progressParam.setEventTime(System.currentTimeMillis());
+    progressParam.setMessage(message);
+    client.onBuildTaskProgress(progressParam);
+  }
+
+  private void taskFinished(TaskId taskId, String message,
+      StatusCode statusCode) {
+    TaskFinishParams endParam = new TaskFinishParams(taskId, statusCode);
+    endParam.setEventTime(System.currentTimeMillis());
+    endParam.setMessage(message);
+    client.onBuildTaskFinish(endParam);
+  }
+}

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/ProgressReporter.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/ProgressReporter.java
@@ -53,8 +53,11 @@ public abstract class ProgressReporter implements ProgressListener {
     }
   }
 
-  protected TaskId getTaskId(String taskPath) {
-    TaskId taskId = new TaskId(taskPath == null ? "null" : taskPath);
+  protected TaskId getTaskId(String description) {
+    if (description == null) {
+      return taskId;
+    }
+    TaskId taskId = new TaskId(description);
     taskId.setParents(taskIds);
     return taskId;
   }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/TestNameRecorder.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/TestNameRecorder.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.core.internal.reporter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.gradle.tooling.events.ProgressEvent;
+import org.gradle.tooling.events.ProgressListener;
+import org.gradle.tooling.events.test.JvmTestOperationDescriptor;
+
+/**
+ * Implements {@link ProgressListener} that listens to the progress of gradle test tasks,
+ * and records the names of the tests.
+ */
+public class TestNameRecorder implements ProgressListener {
+
+  private final Set<String> mainClasses;
+
+  public TestNameRecorder() {
+    mainClasses = new HashSet<>();
+  }
+
+  @Override
+  public void statusChanged(ProgressEvent event) {
+    if (event.getDescriptor() instanceof JvmTestOperationDescriptor) {
+      JvmTestOperationDescriptor descriptor = (JvmTestOperationDescriptor) event.getDescriptor();
+      if (descriptor.getClassName() != null && descriptor.getMethodName() == null) {
+        mainClasses.add(descriptor.getClassName());
+      }
+    }
+  }
+
+  public Set<String> getMainClasses() {
+    return mainClasses;
+  }
+}

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/TestReportReporter.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/TestReportReporter.java
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.core.internal.reporter;
+
+import ch.epfl.scala.bsp4j.TaskId;
+import ch.epfl.scala.bsp4j.TaskStartParams;
+import ch.epfl.scala.bsp4j.TestFinish;
+import ch.epfl.scala.bsp4j.TestStart;
+import ch.epfl.scala.bsp4j.TestStatus;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.gradle.tooling.events.FinishEvent;
+import org.gradle.tooling.events.OperationResult;
+import org.gradle.tooling.events.ProgressEvent;
+import org.gradle.tooling.events.StartEvent;
+import org.gradle.tooling.events.test.JvmTestOperationDescriptor;
+import org.gradle.tooling.events.test.TestFailureResult;
+import org.gradle.tooling.events.test.TestSkippedResult;
+import org.gradle.tooling.events.test.TestSuccessResult;
+
+import ch.epfl.scala.bsp4j.BuildClient;
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.StatusCode;
+import ch.epfl.scala.bsp4j.TaskFinishParams;
+import ch.epfl.scala.bsp4j.TestReport;
+import org.gradle.tooling.internal.consumer.DefaultTestAssertionFailure;
+
+/**
+ * Implements {@link ProgressReporter} to record test results.
+ * Test summary report. e.g. number of fails.
+ */
+public class TestReportReporter extends ProgressReporter {
+
+  private final BuildTargetIdentifier btId;
+  private int successCount;
+  private int skippedCount;
+  private int failureCount;
+  private Long latestTime;
+  private RuntimeException exception;
+
+  /**
+   * initialise.
+   *
+   * @param btId the build target being tested.
+   */
+  public TestReportReporter(BuildTargetIdentifier btId, BuildClient client, String originId) {
+    super(client, originId);
+    this.btId = btId;
+    successCount = 0;
+    skippedCount = 0;
+    failureCount = 0;
+    latestTime = null;
+    exception = null;
+  }
+
+  @Override
+  public void statusChanged(ProgressEvent event) {
+    if (client != null) {
+      if (event.getDescriptor() instanceof JvmTestOperationDescriptor) {
+        // only report on methods
+        JvmTestOperationDescriptor descriptor = (JvmTestOperationDescriptor) event.getDescriptor();
+        if (descriptor.getClassName() != null && descriptor.getMethodName() != null) {
+          TaskId taskId = getTaskId(descriptor.getDisplayName());
+          if (event instanceof StartEvent) {
+            TaskStartParams startParam = new TaskStartParams(taskId);
+            startParam.setMessage("Start test");
+            startParam.setDataKind("test-start");
+            startParam.setEventTime(event.getEventTime());
+            TestStart testStart = new TestStart(event.getDisplayName());
+            // TODO Gradle does not provide file/position data
+            startParam.setData(testStart);
+            client.onBuildTaskStart(startParam);
+          } else if (event instanceof FinishEvent) {
+            OperationResult result = ((FinishEvent) event).getResult();
+            StatusCode statusCode = StatusCode.OK;
+            TestStatus testStatus = TestStatus.PASSED;
+            String stackTrace = null;
+            if (result instanceof TestFailureResult) {
+              statusCode = StatusCode.ERROR;
+              testStatus = TestStatus.FAILED;
+              stackTrace = ((TestFailureResult) result).getFailures()
+                  .stream()
+                  .filter(f -> f instanceof DefaultTestAssertionFailure)
+                  .map(f -> (DefaultTestAssertionFailure) f)
+                  .map(DefaultTestAssertionFailure::getStacktrace)
+                  .findFirst()
+                  .orElse(null);
+              failureCount += 1;
+            } else if (result instanceof TestSkippedResult) {
+              testStatus = TestStatus.SKIPPED;
+              skippedCount += 1;
+            } else if (result instanceof TestSuccessResult) {
+              successCount += 1;
+            }
+            TaskFinishParams finishParam = new TaskFinishParams(taskId, statusCode);
+            finishParam.setMessage("Finish test");
+            finishParam.setDataKind("test-finish");
+            finishParam.setEventTime(event.getEventTime());
+            TestFinish testFinish = new TestFinish(event.getDisplayName(), testStatus);
+            // TODO Gradle does not provide file/position data
+            // TODO BSP does not offer a way to pass back stacktrace
+            testFinish.setMessage(stackTrace);
+            finishParam.setData(testFinish);
+            client.onBuildTaskFinish(finishParam);
+            latestTime = event.getEventTime();
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Add any exception not dealt with by the progress events.
+   *
+   * @param e exception in test run
+   */
+  public void addException(RuntimeException e) {
+    // just report a single exception as it must be an issue with a connection to Gradle
+    // or an API support issue because of Gradle version
+    // Individual test exceptions are reported elsewhere.
+    exception = e;
+  }
+
+  /**
+   * send the test summary back to the BSP client.
+   */
+  public void sendResult() {
+    if (client != null) {
+      StatusCode statusCode = StatusCode.OK;
+      if (failureCount > 0 || exception != null) {
+        statusCode = StatusCode.ERROR;
+      }
+      TaskFinishParams finishParam = new TaskFinishParams(taskId, statusCode);
+      if (exception != null) {
+        String message = String.join("\n", ExceptionUtils.getRootCauseStackTraceList(exception));
+        finishParam.setMessage("Exception in tests " + message);
+      } else {
+        finishParam.setMessage("Finish test");
+      }
+      finishParam.setDataKind("test-report");
+      finishParam.setEventTime(latestTime);
+      TestReport testFinish = new TestReport(btId, successCount, failureCount, 0, 0, skippedCount);
+      finishParam.setData(testFinish);
+      client.onBuildTaskFinish(finishParam);
+    }
+  }
+}

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
@@ -41,6 +41,11 @@ import ch.epfl.scala.bsp4j.InverseSourcesResult;
 import ch.epfl.scala.bsp4j.JavaBuildServer;
 import ch.epfl.scala.bsp4j.JavacOptionsParams;
 import ch.epfl.scala.bsp4j.JavacOptionsResult;
+import ch.epfl.scala.bsp4j.JvmBuildServer;
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
 import ch.epfl.scala.bsp4j.OutputPathsParams;
 import ch.epfl.scala.bsp4j.OutputPathsResult;
 import ch.epfl.scala.bsp4j.ResourcesParams;
@@ -63,11 +68,12 @@ import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 /**
  * The implementation of the Build Server Protocol.
  */
-public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBuildServer {
+public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBuildServer,
+    JvmBuildServer {
 
-  private LifecycleService lifecycleService;
+  private final LifecycleService lifecycleService;
 
-  private BuildTargetService buildTargetService;
+  private final BuildTargetService buildTargetService;
 
   public GradleBuildServer(LifecycleService lifecycleService,
       BuildTargetService buildTargetService) {
@@ -149,14 +155,12 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
 
   @Override
   public CompletableFuture<TestResult> buildTargetTest(TestParams params) {
-    // TODO Auto-generated method stub
-    throw new UnsupportedOperationException("Unimplemented method 'buildTargetTest'");
+    return handleRequest("buildTarget/test", cc -> buildTargetService.buildTargetTest(params));
   }
 
   @Override
   public CompletableFuture<RunResult> buildTargetRun(RunParams params) {
-    // TODO Auto-generated method stub
-    throw new UnsupportedOperationException("Unimplemented method 'buildTargetRun'");
+    return handleRequest("buildTarget/run", cc -> buildTargetService.buildTargetRun(params));
   }
 
   @Override
@@ -202,6 +206,21 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
       ScalaMainClassesParams params) {
     // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'buildTargetScalaMainClasses'");
+  }
+
+  @Override
+  public CompletableFuture<JvmRunEnvironmentResult> jvmRunEnvironment(
+      JvmRunEnvironmentParams params) {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException(
+      "Unimplemented method 'buildTarget/jvmRunEnvironment'");
+  }
+
+  @Override
+  public CompletableFuture<JvmTestEnvironmentResult> jvmTestEnvironment(
+      JvmTestEnvironmentParams params) {
+    return handleRequest("buildTarget/jvmTestEnvironment", cc ->
+        buildTargetService.getBuildTargetJvmTestEnvironment(params));
   }
 
   private void handleNotification(String methodName, Runnable runnable, boolean async) {

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -8,6 +8,7 @@ import static com.microsoft.java.bs.core.Launcher.LOGGER;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,11 +26,14 @@ import com.microsoft.java.bs.core.internal.model.GradleBuildTarget;
 import com.microsoft.java.bs.core.internal.reporter.CompileProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.DefaultProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.ProgressReporter;
+import com.microsoft.java.bs.core.internal.model.GradleTestEntity;
+import com.microsoft.java.bs.core.internal.utils.JsonUtils;
 import com.microsoft.java.bs.core.internal.utils.TelemetryUtils;
 import com.microsoft.java.bs.core.internal.utils.UriUtils;
 import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
+import com.microsoft.java.bs.gradle.model.GradleTestTask;
 import com.microsoft.java.bs.gradle.model.JavaExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
@@ -52,6 +56,10 @@ import ch.epfl.scala.bsp4j.DependencySourcesResult;
 import ch.epfl.scala.bsp4j.JavacOptionsItem;
 import ch.epfl.scala.bsp4j.JavacOptionsParams;
 import ch.epfl.scala.bsp4j.JavacOptionsResult;
+import ch.epfl.scala.bsp4j.JvmEnvironmentItem;
+import ch.epfl.scala.bsp4j.JvmMainClass;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
 import ch.epfl.scala.bsp4j.DidChangeBuildTarget;
 import ch.epfl.scala.bsp4j.MavenDependencyModule;
 import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
@@ -63,15 +71,24 @@ import ch.epfl.scala.bsp4j.OutputPathsResult;
 import ch.epfl.scala.bsp4j.ResourcesItem;
 import ch.epfl.scala.bsp4j.ResourcesParams;
 import ch.epfl.scala.bsp4j.ResourcesResult;
+import ch.epfl.scala.bsp4j.RunParams;
+import ch.epfl.scala.bsp4j.RunParamsDataKind;
+import ch.epfl.scala.bsp4j.RunResult;
 import ch.epfl.scala.bsp4j.ScalacOptionsItem;
 import ch.epfl.scala.bsp4j.ScalacOptionsParams;
 import ch.epfl.scala.bsp4j.ScalacOptionsResult;
+import ch.epfl.scala.bsp4j.ScalaMainClass;
+import ch.epfl.scala.bsp4j.ScalaTestClassesItem;
+import ch.epfl.scala.bsp4j.ScalaTestParams;
 import ch.epfl.scala.bsp4j.SourceItem;
 import ch.epfl.scala.bsp4j.SourceItemKind;
 import ch.epfl.scala.bsp4j.SourcesItem;
 import ch.epfl.scala.bsp4j.SourcesParams;
 import ch.epfl.scala.bsp4j.SourcesResult;
 import ch.epfl.scala.bsp4j.StatusCode;
+import ch.epfl.scala.bsp4j.TestParams;
+import ch.epfl.scala.bsp4j.TestParamsDataKind;
+import ch.epfl.scala.bsp4j.TestResult;
 import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 import org.apache.commons.lang3.StringUtils;
 
@@ -467,6 +484,141 @@ public class BuildTargetService {
       ));
     }
     return new ScalacOptionsResult(items);
+  }
+
+  /**
+   * get the test classes.
+   */
+  public JvmTestEnvironmentResult getBuildTargetJvmTestEnvironment(
+      JvmTestEnvironmentParams params) {
+    Map<BuildTargetIdentifier, List<GradleTestEntity>> mainClassesMap = new HashMap<>();
+    Map<URI, Set<BuildTargetIdentifier>> groupedTargets =
+        groupBuildTargetsByRootDir(params.getTargets());
+    // retrieving tests can trigger compilation that must be reported on
+    CompileProgressReporter compileProgressReporter = new CompileProgressReporter(client,
+            params.getOriginId(), getFullTaskPathMap());
+    for (Map.Entry<URI, Set<BuildTargetIdentifier>> entry : groupedTargets.entrySet()) {
+      Map<BuildTargetIdentifier, Set<GradleTestTask>> testTaskMap = new HashMap<>();
+      for (BuildTargetIdentifier btId : entry.getValue()) {
+        GradleBuildTarget target = buildTargetManager.getGradleBuildTarget(btId);
+        if (target == null) {
+          LOGGER.warning("Skip test collection for the build target: " + btId.getUri()
+              + ". Because it cannot be found in the cache.");
+          continue;
+        }
+        testTaskMap.put(btId, target.getSourceSet().getTestTasks());
+      }
+      URI projectUri = entry.getKey();
+      Map<BuildTargetIdentifier, List<GradleTestEntity>> partialMainClassesMap =
+          connector.getTestClasses(projectUri, testTaskMap, client, compileProgressReporter);
+      mainClassesMap.putAll(partialMainClassesMap);
+    }
+    List<JvmEnvironmentItem> items = new ArrayList<>();
+    for (Map.Entry<BuildTargetIdentifier, List<GradleTestEntity>> entry :
+        mainClassesMap.entrySet()) {
+      for (GradleTestEntity gradleTestEntity : entry.getValue()) {
+        GradleTestTask gradleTestTask = gradleTestEntity.getGradleTestTask();
+        List<String> classpath = gradleTestTask.getClasspath()
+            .stream()
+            .map(file -> file.toURI().toString())
+            .collect(Collectors.toList());
+        List<String> jvmOptions = gradleTestTask.getJvmOptions();
+        String workingDirectory = gradleTestTask.getWorkingDirectory().toURI().toString();
+        Map<String, String> environmentVariables = gradleTestTask.getEnvironmentVariables();
+        List<JvmMainClass> mainClasses = gradleTestEntity.getTestClasses()
+            .stream()
+            .map(mainClass -> new JvmMainClass(mainClass, Collections.emptyList()))
+            .collect(Collectors.toList());
+        JvmEnvironmentItem item = new JvmEnvironmentItem(entry.getKey(),
+            classpath, jvmOptions, workingDirectory, environmentVariables);
+        item.setMainClasses(mainClasses);
+        items.add(item);
+      }
+    }
+    return new JvmTestEnvironmentResult(items);
+  }
+
+  /**
+   * Run the test classes.
+   */
+  public TestResult buildTargetTest(TestParams params) {
+    TestResult testResult = new TestResult(StatusCode.OK);
+    testResult.setOriginId(params.getOriginId());
+    if (!TestParamsDataKind.SCALA_TEST.equals(params.getDataKind())) {
+      LOGGER.warning("Test Data Kind " + params.getDataKind() + " not supported");
+      testResult.setStatusCode(StatusCode.ERROR);
+    } else {
+      // running tests can trigger compilation that must be reported on
+      CompileProgressReporter compileProgressReporter = new CompileProgressReporter(client,
+              params.getOriginId(), getFullTaskPathMap());
+      Map<URI, Set<BuildTargetIdentifier>> groupedTargets =
+          groupBuildTargetsByRootDir(params.getTargets());
+      for (Map.Entry<URI, Set<BuildTargetIdentifier>> entry : groupedTargets.entrySet()) {
+        // ideally BSP would have a jvmTestEnv style testkind for executing tests, not scala.
+        ScalaTestParams testParams = JsonUtils.toModel(params.getData(), ScalaTestParams.class);
+        Map<BuildTargetIdentifier, Set<String>> testClasses =
+            testParams.getTestClasses().stream()
+              .collect(Collectors.toMap(ScalaTestClassesItem::getTarget,
+                item -> item.getClasses().stream().collect(Collectors.toSet())));
+
+        StatusCode statusCode = connector.runTestClasses(entry.getKey(), testClasses,
+            client, params.getOriginId(), compileProgressReporter);
+
+        if (statusCode != StatusCode.OK) {
+          testResult.setStatusCode(statusCode);
+        }
+      }
+    }
+    return testResult;    
+  }
+
+  /**
+   * Run the main class.
+   */
+  public RunResult buildTargetRun(RunParams params) {
+    RunResult runResult = new RunResult(StatusCode.OK);
+    runResult.setOriginId(params.getOriginId());
+    if (!RunParamsDataKind.SCALA_MAIN_CLASS.equals(params.getDataKind())) {
+      LOGGER.warning("Run Data Kind " + params.getDataKind() + " not supported");
+      runResult.setStatusCode(StatusCode.ERROR);
+    } else {
+      // running tests can trigger compilation that must be reported on
+      CompileProgressReporter compileProgressReporter = new CompileProgressReporter(client,
+              params.getOriginId(), getFullTaskPathMap());
+      GradleBuildTarget buildTarget = getGradleBuildTarget(params.getTarget());
+      if (buildTarget == null) {
+        // TODO: https://github.com/microsoft/build-server-for-gradle/issues/50
+        throw new IllegalArgumentException("The build target does not exist: "
+          + params.getTarget().getUri());
+      }
+      URI projectUri = getRootProjectUri(params.getTarget());
+      // ideally BSP would have a jvmRunEnv style runkind for executing tests, not scala.
+      ScalaMainClass mainClass = JsonUtils.toModel(params.getData(), ScalaMainClass.class);
+      // TODO it's not clear which argument set takes precedence
+      List<String> arguments1 = params.getArguments();
+      List<String> arguments2 = mainClass.getArguments();
+      List<String> argumentsToUse;
+      if (arguments1 == null || arguments1.isEmpty()) {
+        argumentsToUse = arguments2;
+      } else {
+        argumentsToUse = arguments1;
+      }
+      // TODO upgrade to later BSP version and then env vars can be passed to runMainClass
+      StatusCode statusCode = connector.runMainClass(projectUri,
+              buildTarget.getSourceSet().getProjectPath(),
+              buildTarget.getSourceSet().getSourceSetName(),
+              mainClass.getClassName(),
+              null,
+              mainClass.getJvmOptions(),
+              argumentsToUse,
+              client,
+              compileProgressReporter);
+
+      if (statusCode != StatusCode.OK) {
+        runResult.setStatusCode(statusCode);
+      }
+    }
+    return runResult;
   }
 
   /**

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
@@ -89,6 +89,7 @@ public class LifecycleService {
     capabilities.setCanReload(true);
     capabilities.setBuildTargetChangedProvider(true);
     capabilities.setCompileProvider(new CompileProvider(SupportedLanguages.allBspNames));
+    capabilities.setJvmTestEnvironmentProvider(true);
     return capabilities;
   }
 

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -12,18 +12,29 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.microsoft.java.bs.gradle.model.ScalaExtension;
-import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.microsoft.java.bs.core.Launcher;
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
+import com.microsoft.java.bs.core.internal.model.GradleTestEntity;
 import com.microsoft.java.bs.core.internal.model.Preferences;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
+import com.microsoft.java.bs.gradle.model.GradleTestTask;
+import com.microsoft.java.bs.gradle.model.ScalaExtension;
+import com.microsoft.java.bs.gradle.model.SupportedLanguages;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.StatusCode;
 
 class GradleApiConnectorTest {
 
@@ -41,31 +52,27 @@ class GradleApiConnectorTest {
     System.setProperty(Launcher.PROP_PLUGIN_DIR, pluginDir);
   }
 
-  private GradleApiConnector getConnector() {
+  private <A> A withConnector(Function<GradleApiConnector, A> function) {
     PreferenceManager preferenceManager = new PreferenceManager();
-    preferenceManager.setClientSupportedLanguages(SupportedLanguages.allBspNames);
     preferenceManager.setPreferences(new Preferences());
-    return new GradleApiConnector(preferenceManager);
-  }
-
-  private GradleSourceSets getGradleSourceSets(File projectDir) {
-    GradleApiConnector connector = getConnector();
+    preferenceManager.setClientSupportedLanguages(SupportedLanguages.allBspNames);
+    GradleApiConnector connector = new GradleApiConnector(preferenceManager);
     try {
-      return connector.getGradleSourceSets(projectDir.toURI(), null);
+      return function.apply(connector);
     } finally {
       connector.shutdown();
     }
+  }
+
+  private GradleSourceSets getGradleSourceSets(File projectDir) {
+    return withConnector(connector -> connector.getGradleSourceSets(projectDir.toURI(), null));
   }
 
   @Test
   void testGetGradleVersion() {
     File projectDir = projectPath.resolve("gradle-4.3-with-wrapper").toFile();
-    GradleApiConnector connector = getConnector();
-    try {
-      assertEquals("4.3", connector.getGradleVersion(projectDir.toURI()));
-    } finally {
-      connector.shutdown();
-    }
+    String version = withConnector(connector -> connector.getGradleVersion(projectDir.toURI()));
+    assertEquals("4.3", version);
   }
 
   @Test
@@ -102,6 +109,14 @@ class GradleApiConnectorTest {
     return sourceSet;
   }
 
+  private void assertHasTaskPath(Set<GradleTestTask> paths, String path) {
+    assertTrue(paths.stream().anyMatch(task -> task.getTaskPath().equals(path)), () -> {
+      String pathsAsStr = paths.stream().map(task -> task.getTaskPath())
+          .collect(Collectors.joining(", "));
+      return "Task path not found [" + path + "] in [" + pathsAsStr + ']';
+    });
+  }
+
   @Test
   void testGetGradleDuplicateNestedProjectNames() {
     File projectDir = projectPath.resolve("duplicate-nested-project-names").toFile();
@@ -126,11 +141,21 @@ class GradleApiConnectorTest {
     File projectDir = projectPath.resolve("test-tag").toFile();
     GradleSourceSets gradleSourceSets = getGradleSourceSets(projectDir);
     assertEquals(5, gradleSourceSets.getGradleSourceSets().size());
-    assertFalse(findSourceSet(gradleSourceSets, "test-tag [main]").hasTests());
-    assertTrue(findSourceSet(gradleSourceSets, "test-tag [test]").hasTests());
-    assertFalse(findSourceSet(gradleSourceSets, "test-tag [noTests]").hasTests());
-    assertTrue(findSourceSet(gradleSourceSets, "test-tag [intTest]").hasTests());
-    assertFalse(findSourceSet(gradleSourceSets, "test-tag [testFixtures]").hasTests());
+
+    GradleSourceSet main = findSourceSet(gradleSourceSets, "test-tag [main]");
+    assertFalse(main.hasTests());
+    GradleSourceSet test = findSourceSet(gradleSourceSets, "test-tag [test]");
+    assertTrue(test.hasTests());
+    assertEquals(1, test.getTestTasks().size());
+    assertHasTaskPath(test.getTestTasks(), ":test");
+    GradleSourceSet noTests = findSourceSet(gradleSourceSets, "test-tag [noTests]");
+    assertFalse(noTests.hasTests());
+    GradleSourceSet intTest = findSourceSet(gradleSourceSets, "test-tag [intTest]");
+    assertTrue(intTest.hasTests());
+    assertEquals(1, intTest.getTestTasks().size());
+    assertHasTaskPath(intTest.getTestTasks(), ":integrationTest");
+    GradleSourceSet testFixtures = findSourceSet(gradleSourceSets, "test-tag [testFixtures]");
+    assertFalse(testFixtures.hasTests());
   }
 
   private void assertHasBuildTargetDependency(GradleSourceSet sourceSet,
@@ -273,5 +298,68 @@ class GradleApiConnectorTest {
     assertFalse(scalaExtension.getScalaCompilerArgs().isEmpty());
     assertTrue(scalaExtension.getScalaCompilerArgs().stream()
         .anyMatch(arg -> arg.equals("-deprecation")));
+  }
+
+  @Test
+  void testGetJvmTestEnviroment() {
+    File projectDir = projectPath.resolve("junit5-jupiter-starter-gradle").toFile();
+    withConnector(connector -> {
+      GradleSourceSets gradleSourceSets = connector.getGradleSourceSets(projectDir.toURI(), null);
+
+      Map<BuildTargetIdentifier, Set<GradleTestTask>> testTaskMap = new HashMap<>();
+      for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {
+        BuildTargetIdentifier fakeBt = new BuildTargetIdentifier(gradleSourceSet.getDisplayName());
+        testTaskMap.put(fakeBt, gradleSourceSet.getTestTasks());
+      }
+      Map<BuildTargetIdentifier, List<GradleTestEntity>> tests =
+            connector.getTestClasses(projectDir.toURI(), testTaskMap, null, null);
+      assertHasTestClass(tests, "junit5-jupiter-starter-gradle [test]",
+          "com.example.project.CalculatorTests");
+      return null;
+    });
+  }
+
+  private void assertHasTestClass(Map<BuildTargetIdentifier, List<GradleTestEntity>> tests,
+      String sourceSetDisplayName, String className) {
+    List<GradleTestEntity> btTests = tests.entrySet().stream()
+        .filter(entry -> entry.getKey().getUri().equals(sourceSetDisplayName))
+        .flatMap(entry -> entry.getValue().stream())
+        .collect(Collectors.toList());
+    assertFalse(btTests.isEmpty(),
+        () -> "SourceSet " + sourceSetDisplayName + " not found in "
+        + tests.keySet().stream()
+          .map(BuildTargetIdentifier::getUri)
+          .collect(Collectors.joining(", ")));
+
+    List<String> btTestClasses = btTests.stream()
+        .flatMap(entity -> entity.getTestClasses().stream())
+        .collect(Collectors.toList());
+    assertTrue(btTestClasses.contains(className),
+        () -> "Test class " + className + " not found in "
+        + String.join(", ", btTestClasses));
+  }
+
+  @Test
+  void testBuildTargetTest() {
+    File projectDir = projectPath.resolve("java-tests").toFile();
+    withConnector(connector -> {
+      GradleSourceSets gradleSourceSets = connector.getGradleSourceSets(projectDir.toURI(), null);
+      GradleSourceSet testSourceSet =
+          findSourceSet(gradleSourceSets, "java-tests [test]");
+      Map<BuildTargetIdentifier, Set<String>> testClassesMap = new HashMap<>();
+      BuildTargetIdentifier fakeBt = new BuildTargetIdentifier(testSourceSet.getDisplayName());
+      Set<String> classes = new HashSet<>();
+      testClassesMap.put(fakeBt, classes);
+      classes.add("com.example.project.PassingTests");
+      StatusCode passingTest = connector.runTestClasses(projectDir.toURI(),
+          testClassesMap, null, null, null);
+      assertEquals(StatusCode.OK, passingTest);
+      classes.clear();
+      classes.add("com.example.project.FailingTests");
+      StatusCode failingTest = connector.runTestClasses(projectDir.toURI(),
+          testClassesMap, null, null, null);
+      assertEquals(StatusCode.ERROR, failingTest);
+      return null;
+    });
   }
 }

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -4,8 +4,10 @@
 package com.microsoft.java.bs.core.internal.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,7 +15,10 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
@@ -30,6 +35,7 @@ import ch.epfl.scala.bsp4j.CleanCacheResult;
 import ch.epfl.scala.bsp4j.CompileParams;
 import ch.epfl.scala.bsp4j.CompileReport;
 import ch.epfl.scala.bsp4j.CompileResult;
+import ch.epfl.scala.bsp4j.CompileTask;
 import ch.epfl.scala.bsp4j.DependencyModulesParams;
 import ch.epfl.scala.bsp4j.DependencyModulesResult;
 import ch.epfl.scala.bsp4j.DependencySourcesParams;
@@ -38,16 +44,32 @@ import ch.epfl.scala.bsp4j.DidChangeBuildTarget;
 import ch.epfl.scala.bsp4j.InitializeBuildParams;
 import ch.epfl.scala.bsp4j.JavaBuildServer;
 import ch.epfl.scala.bsp4j.JvmBuildServer;
+import ch.epfl.scala.bsp4j.JvmEnvironmentItem;
+import ch.epfl.scala.bsp4j.JvmMainClass;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
 import ch.epfl.scala.bsp4j.LogMessageParams;
 import ch.epfl.scala.bsp4j.MavenDependencyModule;
 import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
 import ch.epfl.scala.bsp4j.MessageType;
 import ch.epfl.scala.bsp4j.PublishDiagnosticsParams;
+import ch.epfl.scala.bsp4j.RunParams;
+import ch.epfl.scala.bsp4j.RunParamsDataKind;
+import ch.epfl.scala.bsp4j.RunResult;
+import ch.epfl.scala.bsp4j.ScalaMainClass;
+import ch.epfl.scala.bsp4j.ScalaTestClassesItem;
+import ch.epfl.scala.bsp4j.ScalaTestParams;
 import ch.epfl.scala.bsp4j.ShowMessageParams;
 import ch.epfl.scala.bsp4j.StatusCode;
 import ch.epfl.scala.bsp4j.TaskFinishParams;
 import ch.epfl.scala.bsp4j.TaskProgressParams;
 import ch.epfl.scala.bsp4j.TaskStartParams;
+import ch.epfl.scala.bsp4j.TestFinish;
+import ch.epfl.scala.bsp4j.TestParams;
+import ch.epfl.scala.bsp4j.TestParamsDataKind;
+import ch.epfl.scala.bsp4j.TestReport;
+import ch.epfl.scala.bsp4j.TestResult;
+import ch.epfl.scala.bsp4j.TestStart;
 import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -72,16 +94,22 @@ class BuildTargetServerIntegrationTest {
 
     private final List<TaskStartParams> startReports = new ArrayList<>();
     private final List<TaskFinishParams> finishReports = new ArrayList<>();
+    private final List<CompileTask> compileTasks = new ArrayList<>();
     private final List<CompileReport> compileReports = new ArrayList<>();
-    private final List<CompileResult> compileResults = new ArrayList<>();
     private final List<LogMessageParams> logMessages = new ArrayList<>();
+    private final List<TestReport> testReports = new ArrayList<>();
+    private final List<TestStart> testStarts = new ArrayList<>();
+    private final List<TestFinish> testFinishes = new ArrayList<>();
 
     void clearMessages() {
       startReports.clear();
       finishReports.clear();
+      compileTasks.clear();
       compileReports.clear();
-      compileResults.clear();
       logMessages.clear();
+      testReports.clear();
+      testStarts.clear();
+      testFinishes.clear();
     }
 
     void waitOnStartReports(int size) {
@@ -92,16 +120,28 @@ class BuildTargetServerIntegrationTest {
       waitOnMessages("Finish Reports", size, finishReports::size);
     }
 
+    void waitOnCompileTasks(int size) {
+      waitOnMessages("Compile Tasks", size, compileTasks::size);
+    }
+
     void waitOnCompileReports(int size) {
       waitOnMessages("Compile Reports", size, compileReports::size);
     }
 
-    void waitOnCompileResults(int size) {
-      waitOnMessages("Compile Results", size, compileResults::size);
-    }
-
     void waitOnLogMessages(int size) {
       waitOnMessages("Log Messages", size, logMessages::size);
+    }
+
+    void waitOnTestReports(int size) {
+      waitOnMessages("Test Reports", size, testReports::size);
+    }
+
+    void waitOnTestStarts(int size) {
+      waitOnMessages("Test Starts", size, testStarts::size);
+    }
+
+    void waitOnTestFinishes(int size) {
+      waitOnMessages("Test Finishes", size, testFinishes::size);
     }
 
     long finishReportErrorCount() {
@@ -159,6 +199,15 @@ class BuildTargetServerIntegrationTest {
 
     @Override
     public void onBuildTaskStart(TaskStartParams params) {
+      if (params.getDataKind() != null) {
+        if (params.getDataKind().equals("compile-task")) {
+          compileTasks.add(JsonUtils.toModel(params.getData(), CompileTask.class));
+        } else if (params.getDataKind().equals("test-start")) {
+          testStarts.add(JsonUtils.toModel(params.getData(), TestStart.class));
+        } else {
+          fail("Task Start kind not handled " + params.getDataKind());
+        }
+      }
       startReports.add(params);
       synchronized (this) {
         notify();
@@ -175,8 +224,12 @@ class BuildTargetServerIntegrationTest {
       if (params.getDataKind() != null) {
         if (params.getDataKind().equals("compile-report")) {
           compileReports.add(JsonUtils.toModel(params.getData(), CompileReport.class));
-        } else if (params.getDataKind().equals("compile-result")) {
-          compileResults.add(JsonUtils.toModel(params.getData(), CompileResult.class));
+        } else if (params.getDataKind().equals("test-report")) {
+          testReports.add(JsonUtils.toModel(params.getData(), TestReport.class));
+        } else if (params.getDataKind().equals("test-finish")) {
+          testFinishes.add(JsonUtils.toModel(params.getData(), TestFinish.class));
+        } else {
+          fail("Task Finish kind not handled " + params.getDataKind());
         }
       }
       finishReports.add(params);
@@ -286,8 +339,38 @@ class BuildTargetServerIntegrationTest {
     }
   }
 
+  private static BuildTargetIdentifier findTarget(List<BuildTarget> targets,
+      String displayName) {
+    Optional<BuildTarget> matchingTargets = targets.stream()
+            .filter(res -> displayName.equals(res.getDisplayName()))
+            .findAny();
+    assertFalse(matchingTargets.isEmpty(), () -> {
+      List<String> targetNames = targets.stream()
+              .map(BuildTarget::getDisplayName)
+              .collect(Collectors.toList());
+      return "Target " + displayName + " not found in " + targetNames;
+    });
+    return matchingTargets.get().getId();
+  }
+
+  private static JvmEnvironmentItem findTest(
+      JvmTestEnvironmentResult testEnvResult, String mainClass) {
+    List<JvmEnvironmentItem> tests = testEnvResult.getItems().stream()
+            .filter(res -> res.getMainClasses().stream()
+                .anyMatch(main -> main.getClassName().equals(mainClass)))
+            .collect(Collectors.toList());
+    assertFalse(tests.isEmpty(), () -> {
+      List<String> classes = testEnvResult.getItems().stream()
+              .flatMap(res -> res.getMainClasses().stream()
+                      .map(JvmMainClass::getClassName))
+              .collect(Collectors.toList());
+      return "Test " + mainClass + " not found in " + classes;
+    });
+    return tests.get(0);
+  }
+
   @Test
-  void testCompilingSingleProjectServer() {
+  void testAllOnSingleProjectServer() {
     withNewTestServer("junit5-jupiter-starter-gradle", (gradleBuildServer, client) -> {
       // get targets
       WorkspaceBuildTargetsResult buildTargetsResult = gradleBuildServer.workspaceBuildTargets()
@@ -298,9 +381,12 @@ class BuildTargetServerIntegrationTest {
       assertEquals(2, btIds.size());
       client.waitOnStartReports(1);
       client.waitOnFinishReports(1);
+      client.waitOnCompileTasks(0);
       client.waitOnCompileReports(0);
-      client.waitOnCompileResults(0);
       client.waitOnLogMessages(0);
+      client.waitOnTestStarts(0);
+      client.waitOnTestFinishes(0);
+      client.waitOnTestReports(0);
       for (TaskFinishParams message : client.finishReports) {
         assertEquals(StatusCode.OK, message.getStatus());
       }
@@ -338,9 +424,12 @@ class BuildTargetServerIntegrationTest {
       assertTrue(cleanResult.getCleaned());
       client.waitOnStartReports(1);
       client.waitOnFinishReports(1);
+      client.waitOnCompileTasks(0);
       client.waitOnCompileReports(0);
-      client.waitOnCompileResults(0);
       client.waitOnLogMessages(0);
+      client.waitOnTestStarts(0);
+      client.waitOnTestFinishes(0);
+      client.waitOnTestReports(0);
       for (TaskFinishParams message : client.finishReports) {
         assertEquals(StatusCode.OK, message.getStatus());
       }
@@ -351,11 +440,17 @@ class BuildTargetServerIntegrationTest {
       compileParams.setOriginId("originId");
       CompileResult compileResult = gradleBuildServer.buildTargetCompile(compileParams).join();
       assertEquals(StatusCode.OK, compileResult.getStatusCode());
-      client.waitOnStartReports(6);
-      client.waitOnFinishReports(6);
-      client.waitOnCompileReports(6);
-      client.waitOnCompileResults(0);
+      client.waitOnStartReports(2);
+      client.waitOnFinishReports(2);
+      client.waitOnCompileTasks(2);
+      client.waitOnCompileReports(2);
       client.waitOnLogMessages(0);
+      client.waitOnTestStarts(0);
+      client.waitOnTestFinishes(0);
+      client.waitOnTestReports(0);
+      for (CompileReport message : client.compileReports) {
+        assertFalse(message.getNoOp());
+      }
       for (TaskFinishParams message : client.finishReports) {
         assertEquals(StatusCode.OK, message.getStatus());
       }
@@ -366,6 +461,283 @@ class BuildTargetServerIntegrationTest {
         assertEquals(0, compileReport.getWarnings());
         assertEquals(0, compileReport.getErrors());
       }
+      client.clearMessages();
+
+      // retrieve test names
+      JvmTestEnvironmentParams testEnvParams = new JvmTestEnvironmentParams(btIds);
+      JvmTestEnvironmentResult testEnvResult =
+              gradleBuildServer.jvmTestEnvironment(testEnvParams).join();
+      JvmEnvironmentItem calculatorTestsItem =
+          findTest(testEnvResult, "com.example.project.CalculatorTests");
+      assertFalse(calculatorTestsItem.getMainClasses().isEmpty());
+      assertFalse(calculatorTestsItem.getClasspath().isEmpty());
+      JvmEnvironmentItem failingTestsItem =
+          findTest(testEnvResult, "com.example.project.FailingTests");
+      assertFalse(failingTestsItem.getMainClasses().isEmpty());
+      assertFalse(failingTestsItem.getClasspath().isEmpty());
+      client.waitOnStartReports(11);
+      client.waitOnFinishReports(11);
+      client.waitOnCompileTasks(2);
+      client.waitOnCompileReports(2);
+      client.waitOnLogMessages(0);
+      client.waitOnTestStarts(0);
+      client.waitOnTestFinishes(0);
+      client.waitOnTestReports(0);
+      for (CompileReport message : client.compileReports) {
+        assertTrue(message.getNoOp());
+      }
+      for (TaskFinishParams message : client.finishReports) {
+        assertEquals(StatusCode.OK, message.getStatus());
+      }
+      client.clearMessages();
+
+      // run passing tests
+      List<String> calculatorMainClasses = new LinkedList<>();
+      calculatorMainClasses.add("com.example.project.CalculatorTests");
+      ScalaTestClassesItem calculatorTestClassesItem =
+          new ScalaTestClassesItem(calculatorTestsItem.getTarget(), calculatorMainClasses);
+      List<ScalaTestClassesItem> calculatorTestClasses = new LinkedList<>();
+      calculatorTestClasses.add(calculatorTestClassesItem);
+      ScalaTestParams calculatorScalaTestParams = new ScalaTestParams();
+      calculatorScalaTestParams.setTestClasses(calculatorTestClasses);
+      TestParams calculatorTestParams = new TestParams(btIds);
+      calculatorTestParams.setOriginId("originId");
+      calculatorTestParams.setDataKind(TestParamsDataKind.SCALA_TEST);
+      calculatorTestParams.setData(calculatorScalaTestParams);
+      TestResult calculatorTestResult =
+          gradleBuildServer.buildTargetTest(calculatorTestParams).join();
+      assertEquals(StatusCode.OK, calculatorTestResult.getStatusCode());
+      assertEquals("originId", calculatorTestResult.getOriginId());
+      // there are 5 tests in this class
+      client.waitOnStartReports(7);
+      client.waitOnFinishReports(8);
+      client.waitOnCompileTasks(2);
+      client.waitOnCompileReports(2);
+      client.waitOnLogMessages(0);
+      client.waitOnTestStarts(5);
+      client.waitOnTestFinishes(5);
+      client.waitOnTestReports(1);
+      for (CompileReport message : client.compileReports) {
+        assertTrue(message.getNoOp());
+      }
+      for (TaskFinishParams message : client.finishReports) {
+        assertEquals(StatusCode.OK, message.getStatus());
+      }
+      TestReport calculatorTestsReport = client.testReports.get(0);
+      assertEquals(5, calculatorTestsReport.getPassed());
+      assertEquals(0, calculatorTestsReport.getCancelled());
+      assertEquals(0, calculatorTestsReport.getFailed());
+      assertEquals(0, calculatorTestsReport.getIgnored());
+      assertEquals(0, calculatorTestsReport.getSkipped());
+      client.clearMessages();
+
+      // run failing tests
+      List<String> failingMainClasses = new LinkedList<>();
+      failingMainClasses.add("com.example.project.FailingTests");
+      ScalaTestClassesItem failingTestClassesItem =
+          new ScalaTestClassesItem(failingTestsItem.getTarget(), failingMainClasses);
+      List<ScalaTestClassesItem> failingTestClasses = new LinkedList<>();
+      failingTestClasses.add(failingTestClassesItem);
+      ScalaTestParams failingScalaTestParams = new ScalaTestParams();
+      failingScalaTestParams.setTestClasses(failingTestClasses);
+      TestParams failingTestParams = new TestParams(btIds);
+      failingTestParams.setOriginId("originId");
+      failingTestParams.setDataKind(TestParamsDataKind.SCALA_TEST);
+      failingTestParams.setData(failingScalaTestParams);
+      TestResult failingTestResult = gradleBuildServer.buildTargetTest(failingTestParams).join();
+      assertEquals(StatusCode.ERROR, failingTestResult.getStatusCode());
+      assertEquals("originId", failingTestResult.getOriginId());
+      // there is 1 test in this class
+      client.waitOnStartReports(3);
+      client.waitOnFinishReports(4);
+      client.waitOnCompileTasks(2);
+      client.waitOnCompileReports(2);
+      client.waitOnLogMessages(0);
+      client.waitOnTestStarts(1);
+      client.waitOnTestFinishes(1);
+      client.waitOnTestReports(1);
+      for (CompileReport message : client.compileReports) {
+        assertTrue(message.getNoOp());
+      }
+      assertEquals(2, client.finishReportErrorCount());
+      TestReport failingTestsReport = client.testReports.get(0);
+      assertEquals(0, failingTestsReport.getPassed());
+      assertEquals(0, failingTestsReport.getCancelled());
+      assertEquals(1, failingTestsReport.getFailed());
+      assertEquals(0, failingTestsReport.getIgnored());
+      assertEquals(0, failingTestsReport.getSkipped());
+      TestFinish failingTestsFinish = client.testFinishes.get(0);
+      // TODO there is no way in BSP to pass back stacktrace so it's in message
+      failingTestsFinish.getMessage()
+          .contains("at com.example.project.FailingTests.failingTest(FailingTests.java:21)");
+      client.clearMessages();
+
+      // run main
+      ScalaMainClass mainClass = new ScalaMainClass("com.example.project.Calculator",
+              Collections.emptyList(), Collections.emptyList());
+      BuildTargetIdentifier btId = findTarget(buildTargetsResult.getTargets(),
+              "junit5-jupiter-starter-gradle [main]");
+      RunParams runParams = new RunParams(btId);
+      runParams.setOriginId("originId");
+      runParams.setDataKind(RunParamsDataKind.SCALA_MAIN_CLASS);
+      runParams.setData(mainClass);
+      RunResult runResult = gradleBuildServer.buildTargetRun(runParams).join();
+      assertEquals("originId", runResult.getOriginId());
+      client.waitOnStartReports(2);
+      client.waitOnFinishReports(2);
+      client.waitOnCompileTasks(1);
+      client.waitOnCompileReports(1);
+      client.waitOnLogMessages(0);
+      client.waitOnTestStarts(0);
+      client.waitOnTestFinishes(0);
+      client.waitOnTestReports(0);
+      for (CompileReport message : client.compileReports) {
+        assertTrue(message.getNoOp());
+      }
+      for (TaskFinishParams message : client.finishReports) {
+        assertEquals(StatusCode.OK, message.getStatus());
+      }
+      assertEquals(StatusCode.OK, runResult.getStatusCode(),
+          () -> client.finishReports.stream().map(TaskFinishParams::getMessage)
+                      .collect(Collectors.joining("\n")));
+      client.clearMessages();
+    });
+  }
+  
+  @Test
+  void testCleanStraightToFindTest() {
+    withNewTestServer("junit5-jupiter-starter-gradle", (gradleBuildServer, client) -> {
+      // get targets
+      WorkspaceBuildTargetsResult buildTargetsResult = gradleBuildServer.workspaceBuildTargets()
+          .join();
+      List<BuildTargetIdentifier> btIds = buildTargetsResult.getTargets().stream()
+          .map(BuildTarget::getId)
+          .collect(Collectors.toList());
+
+      // clean targets
+      CleanCacheParams cleanCacheParams = new CleanCacheParams(btIds);
+      gradleBuildServer.buildTargetCleanCache(cleanCacheParams).join();
+      client.clearMessages();
+
+      // a request to find tests straight after a clean should produce compile results/reports
+      // retrieve test names
+      JvmTestEnvironmentParams testEnvParams = new JvmTestEnvironmentParams(btIds);
+      gradleBuildServer.jvmTestEnvironment(testEnvParams).join();
+      client.waitOnStartReports(11);
+      client.waitOnFinishReports(11);
+      client.waitOnCompileTasks(2);
+      client.waitOnCompileReports(2);
+      client.waitOnLogMessages(0);
+      client.waitOnTestStarts(0);
+      client.waitOnTestFinishes(0);
+      client.waitOnTestReports(0);
+      for (CompileReport message : client.compileReports) {
+        assertFalse(message.getNoOp());
+      }
+      for (TaskFinishParams message : client.finishReports) {
+        assertEquals(StatusCode.OK, message.getStatus());
+      }
+      client.clearMessages();
+    });
+  }
+  
+  @Test
+  void testCleanStraightToTest() {
+    withNewTestServer("junit5-jupiter-starter-gradle", (gradleBuildServer, client) -> {
+      // get targets
+      WorkspaceBuildTargetsResult buildTargetsResult = gradleBuildServer.workspaceBuildTargets()
+          .join();
+      List<BuildTargetIdentifier> btIds = buildTargetsResult.getTargets().stream()
+          .map(BuildTarget::getId)
+          .collect(Collectors.toList());
+
+      // clean targets
+      CleanCacheParams cleanCacheParams = new CleanCacheParams(btIds);
+      gradleBuildServer.buildTargetCleanCache(cleanCacheParams).join();
+      client.clearMessages();
+      
+      // a request to run tests straight after a clean should produce compile results/reports
+      // run tests
+      List<String> mainClasses = new LinkedList<>();
+      mainClasses.add("com.example.project.CalculatorTests");
+      BuildTargetIdentifier btId = findTarget(buildTargetsResult.getTargets(),
+              "junit5-jupiter-starter-gradle [test]");
+      ScalaTestClassesItem scalaTestClassesItem =
+              new ScalaTestClassesItem(btId, mainClasses);
+      List<ScalaTestClassesItem> testClasses = new LinkedList<>();
+      testClasses.add(scalaTestClassesItem);
+      ScalaTestParams scalaTestParams = new ScalaTestParams();
+      scalaTestParams.setTestClasses(testClasses);
+      TestParams testParams = new TestParams(btIds);
+      testParams.setOriginId("originId");
+      testParams.setDataKind(TestParamsDataKind.SCALA_TEST);
+      testParams.setData(scalaTestParams);
+      TestResult testResult = gradleBuildServer.buildTargetTest(testParams).join();
+      assertEquals(StatusCode.OK, testResult.getStatusCode());
+      assertEquals("originId", testResult.getOriginId());
+      // there are 5 tests in this project
+      client.waitOnStartReports(7);
+      client.waitOnFinishReports(8);
+      client.waitOnCompileTasks(2);
+      client.waitOnCompileReports(2);
+      client.waitOnLogMessages(0);
+      client.waitOnTestStarts(5);
+      client.waitOnTestFinishes(5);
+      client.waitOnTestReports(1);
+      for (CompileReport message : client.compileReports) {
+        assertFalse(message.getNoOp());
+      }
+      for (TaskFinishParams message : client.finishReports) {
+        assertEquals(StatusCode.OK, message.getStatus());
+      }
+      client.clearMessages();
+    });
+  }
+
+  @Test
+  void testCleanStraightToRun() {
+    withNewTestServer("junit5-jupiter-starter-gradle", (gradleBuildServer, client) -> {
+      // get targets
+      WorkspaceBuildTargetsResult buildTargetsResult = gradleBuildServer.workspaceBuildTargets()
+          .join();
+      List<BuildTargetIdentifier> btIds = buildTargetsResult.getTargets().stream()
+          .map(BuildTarget::getId)
+          .collect(Collectors.toList());
+
+      // clean targets
+      CleanCacheParams cleanCacheParams = new CleanCacheParams(btIds);
+      gradleBuildServer.buildTargetCleanCache(cleanCacheParams).join();
+      client.clearMessages();
+      
+      // a request to run mainClass straight after a clean should produce compile results/reports
+      // run main
+      ScalaMainClass mainClass = new ScalaMainClass("com.example.project.Calculator",
+          Collections.emptyList(), Collections.emptyList());
+      BuildTargetIdentifier btId = findTarget(buildTargetsResult.getTargets(),
+            "junit5-jupiter-starter-gradle [main]");
+      RunParams runParams = new RunParams(btId);
+      runParams.setOriginId("originId");
+      runParams.setDataKind(RunParamsDataKind.SCALA_MAIN_CLASS);
+      runParams.setData(mainClass);
+      RunResult runResult = gradleBuildServer.buildTargetRun(runParams).join();
+      assertEquals("originId", runResult.getOriginId());
+      client.waitOnStartReports(2);
+      client.waitOnFinishReports(2);
+      client.waitOnCompileTasks(1);
+      client.waitOnCompileReports(1);
+      client.waitOnLogMessages(0);
+      client.waitOnTestStarts(0);
+      client.waitOnTestFinishes(0);
+      client.waitOnTestReports(0);
+      for (CompileReport message : client.compileReports) {
+        assertFalse(message.getNoOp());
+      }
+      for (TaskFinishParams message : client.finishReports) {
+        assertEquals(StatusCode.OK, message.getStatus());
+      }
+      assertEquals(StatusCode.OK, runResult.getStatusCode(),
+          () -> client.finishReports.stream().map(TaskFinishParams::getMessage)
+                    .collect(Collectors.joining("\n")));
       client.clearMessages();
     });
   }
@@ -382,8 +754,8 @@ class BuildTargetServerIntegrationTest {
       assertEquals(2, btIds.size());
       client.waitOnStartReports(1);
       client.waitOnFinishReports(1);
+      client.waitOnCompileTasks(0);
       client.waitOnCompileReports(0);
-      client.waitOnCompileResults(0);
       client.waitOnLogMessages(0);
       for (TaskFinishParams message : client.finishReports) {
         assertEquals(StatusCode.OK, message.getStatus());
@@ -397,8 +769,8 @@ class BuildTargetServerIntegrationTest {
       assertTrue(cleanResult.getCleaned());
       client.waitOnStartReports(1);
       client.waitOnFinishReports(1);
+      client.waitOnCompileTasks(0);
       client.waitOnCompileReports(0);
-      client.waitOnCompileResults(0);
       client.waitOnLogMessages(0);
       for (TaskFinishParams message : client.finishReports) {
         assertEquals(StatusCode.OK, message.getStatus());
@@ -410,11 +782,14 @@ class BuildTargetServerIntegrationTest {
       compileParams.setOriginId("originId");
       CompileResult compileResult = gradleBuildServer.buildTargetCompile(compileParams).join();
       assertEquals(StatusCode.ERROR, compileResult.getStatusCode());
-      client.waitOnStartReports(4);
-      client.waitOnFinishReports(4);
-      client.waitOnCompileReports(4);
-      client.waitOnCompileResults(0);
+      client.waitOnStartReports(2);
+      client.waitOnFinishReports(2);
+      client.waitOnCompileTasks(2);
+      client.waitOnCompileReports(2);
       client.waitOnLogMessages(1);
+      for (CompileReport message : client.compileReports) {
+        assertFalse(message.getNoOp());
+      }
       assertEquals(1, client.finishReportErrorCount());
       for (BuildTargetIdentifier btId : btIds) {
         CompileReport compileReport = client.findCompileReport(btId);

--- a/testProjects/java-tests/build.gradle
+++ b/testProjects/java-tests/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+	id 'java'
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	testImplementation(platform('org.junit:junit-bom:5.9.2'))
+	testImplementation('org.junit.jupiter:junit-jupiter')
+}
+
+test {
+	useJUnitPlatform()
+}

--- a/testProjects/java-tests/settings.gradle
+++ b/testProjects/java-tests/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-tests'

--- a/testProjects/java-tests/src/test/java/com/example/project/FailingTests.java
+++ b/testProjects/java-tests/src/test/java/com/example/project/FailingTests.java
@@ -10,13 +10,13 @@
 
 package com.example.project;
 
-public class Calculator {
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-  public int add(int a, int b) {
-    return a + b;
-  }
+import org.junit.jupiter.api.Test;
 
-  public static void main(String[] args) {
-    System.out.println("Test app");
-  }
+class Tests {
+    @Test
+    void failingTest() {
+        assertTrue(false);
+    }
 }

--- a/testProjects/java-tests/src/test/java/com/example/project/PassingTests.java
+++ b/testProjects/java-tests/src/test/java/com/example/project/PassingTests.java
@@ -10,13 +10,13 @@
 
 package com.example.project;
 
-public class Calculator {
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-  public int add(int a, int b) {
-    return a + b;
-  }
+import org.junit.jupiter.api.Test;
 
-  public static void main(String[] args) {
-    System.out.println("Test app");
-  }
+class PassingTests {
+    @Test
+    void passingTest() {
+        assertTrue(true);
+    }
 }

--- a/testProjects/junit5-jupiter-starter-gradle/src/test/java/com/example/project/CalculatorTests.java
+++ b/testProjects/junit5-jupiter-starter-gradle/src/test/java/com/example/project/CalculatorTests.java
@@ -19,23 +19,23 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 class CalculatorTests {
 
-	@Test
-	@DisplayName("1 + 1 = 2")
-	void addsTwoNumbers() {
-		Calculator calculator = new Calculator();
-		assertEquals(2, calculator.add(1, 1), "1 + 1 should equal 2");
-	}
+  @Test
+  @DisplayName("1 + 1 = 2")
+  void addsTwoNumbers() {
+    Calculator calculator = new Calculator();
+    assertEquals(2, calculator.add(1, 1), "1 + 1 should equal 2");
+  }
 
-	@ParameterizedTest(name = "{0} + {1} = {2}")
-	@CsvSource({
-			"0,    1,   1",
-			"1,    2,   3",
-			"49,  51, 100",
-			"1,  100, 101"
-	})
-	void add(int first, int second, int expectedResult) {
-		Calculator calculator = new Calculator();
-		assertEquals(expectedResult, calculator.add(first, second),
-				() -> first + " + " + second + " should equal " + expectedResult);
-	}
+  @ParameterizedTest(name = "{0} + {1} = {2}")
+  @CsvSource({
+      "0,    1,   1",
+      "1,    2,   3",
+      "49,  51, 100",
+      "1,  100, 101"
+  })
+  void add(int first, int second, int expectedResult) {
+    Calculator calculator = new Calculator();
+    assertEquals(expectedResult, calculator.add(first, second),
+        () -> first + " + " + second + " should equal " + expectedResult);
+  }
 }

--- a/testProjects/junit5-jupiter-starter-gradle/src/test/java/com/example/project/FailingTests.java
+++ b/testProjects/junit5-jupiter-starter-gradle/src/test/java/com/example/project/FailingTests.java
@@ -10,13 +10,14 @@
 
 package com.example.project;
 
-public class Calculator {
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-  public int add(int a, int b) {
-    return a + b;
-  }
+import org.junit.jupiter.api.Test;
 
-  public static void main(String[] args) {
-    System.out.println("Test app");
+class FailingTests {
+ 
+  @Test
+  void failingTest() {
+    assertTrue(false);
   }
 }


### PR DESCRIPTION
Implements BSP test discovery.  Only returns the classes but BSP doesn't seem to allow test discovery down to the method level.

Requires Gradle >= 8.3 as `--test-dry-run` has only recently been added.  There doesn't appear to be any other way to discover tests.

This is what this project looks like in VSCode test explorer
![image](https://github.com/microsoft/build-server-for-gradle/assets/5612295/93743769-0caf-4d16-a625-eeb5b6f95360)
