### PR TITLE
Support buildTarget/dependencySources

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Following BSP requests are supported in the current implementation:
 - `buildTarget/resources`
 - `buildTarget/outputPaths`
 - `buildTarget/dependencyModules`
+- `buildTarget/dependencySources`
 - `buildTarget/compile`
 - `buildTarget/cleanCache`
 - `buildTarget/javacOptions`

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
@@ -124,8 +124,8 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
   @Override
   public CompletableFuture<DependencySourcesResult> buildTargetDependencySources(
       DependencySourcesParams params) {
-    // TODO Auto-generated method stub
-    throw new UnsupportedOperationException("Unimplemented method 'buildTargetDependencySources'");
+    return handleRequest("buildTarget/dependencySources", cc ->
+            buildTargetService.getBuildTargetDependencySources(params));
   }
 
   @Override

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
@@ -103,6 +103,7 @@ public class LifecycleService {
     capabilities.setResourcesProvider(true);
     capabilities.setOutputPathsProvider(true);
     capabilities.setDependencyModulesProvider(true);
+    capabilities.setDependencySourcesProvider(true);
     capabilities.setCanReload(true);
     capabilities.setBuildTargetChangedProvider(true);
     capabilities.setCompileProvider(new CompileProvider(SupportedLanguages.allBspNames));


### PR DESCRIPTION
Not all clients support the newer `buildTarget/dependencyModules` so I've added support for the older `buildTarget/dependencySources`