### PR TITLE
Initial Groovy support

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GroovyExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GroovyExtension.java
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model;
+
+/**
+ * The extension model for Groovy language.
+ */
+public interface GroovyExtension extends LanguageExtension {
+    // unknown what is required by Groovy BSP clients so leave blank for now
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/LanguageExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/LanguageExtension.java
@@ -58,6 +58,13 @@ public interface LanguageExtension extends Serializable {
   boolean isScalaExtension();
 
   /**
+   * Checks if the implementing class is a {@link GroovyExtension}.
+   *
+   * @return true if the extension is for Scala, false otherwise.
+   */
+  boolean isGroovyExtension();
+
+  /**
    * Attempts to cast the current object to a {@link JavaExtension} instance.
    * <p>
    * This method should ideally be used only when the implementing class
@@ -80,4 +87,17 @@ public interface LanguageExtension extends Serializable {
    *        or null if the cast fails.
    */
   ScalaExtension getAsScalaExtension();
+
+  /**
+   * Attempts to cast the current object to a {@link GroovyExtension} instance.
+   * <p>
+   * This method should ideally be used only when the implementing class
+   * is known to be a {@link GroovyExtension}.
+   * </p>
+   *
+   * @return the current object cast to a {@link GroovyExtension} instance,
+   *        or null if the cast fails.
+   */
+  GroovyExtension getAsGroovyExtension();
+
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/SupportedLanguages.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/SupportedLanguages.java
@@ -5,6 +5,7 @@ package com.microsoft.java.bs.gradle.model;
 
 import com.microsoft.java.bs.gradle.model.impl.DefaultJavaLanguage;
 import com.microsoft.java.bs.gradle.model.impl.DefaultScalaLanguage;
+import com.microsoft.java.bs.gradle.model.impl.DefaultGroovyLanguage;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 public class SupportedLanguages {
   public static final DefaultJavaLanguage JAVA = new DefaultJavaLanguage();
   public static final DefaultScalaLanguage SCALA = new DefaultScalaLanguage();
+  public static final DefaultGroovyLanguage GROOVY = new DefaultGroovyLanguage();
 
   public static final List<SupportedLanguage<?>> all;
   public static final List<String> allBspNames;
@@ -24,6 +26,7 @@ public class SupportedLanguages {
     all = new LinkedList<>();
     all.add(JAVA);
     all.add(SCALA);
+    all.add(GROOVY);
     allBspNames = all.stream().map(SupportedLanguage::getBspName).collect(Collectors.toList());
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -107,6 +107,10 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
       return object.getAsScalaExtension();
     }
 
+    if (object.isGroovyExtension()) {
+      return object.getAsGroovyExtension();
+    }
+
     throw new IllegalArgumentException("No conversion methods defined for object: " + object);
   }
 

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGroovyExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGroovyExtension.java
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model.impl;
+
+import java.io.File;
+import java.util.Objects;
+import java.util.Set;
+
+import com.microsoft.java.bs.gradle.model.GroovyExtension;
+import com.microsoft.java.bs.gradle.model.JavaExtension;
+import com.microsoft.java.bs.gradle.model.ScalaExtension;
+
+/**
+ * Default implementation of {@link GroovyExtension}.
+ */
+public class DefaultGroovyExtension implements GroovyExtension {
+  private static final long serialVersionUID = 1L;
+  
+  private Set<File> sourceDirs;
+
+  private Set<File> generatedSourceDirs;
+
+  private String compileTaskName;
+
+  private File classesDir;
+
+  @Override
+  public Set<File> getSourceDirs() {
+    return sourceDirs;
+  }
+
+  public void setSourceDirs(Set<File> sourceDirs) {
+    this.sourceDirs = sourceDirs;
+  }
+
+  @Override
+  public Set<File> getGeneratedSourceDirs() {
+    return generatedSourceDirs;
+  }
+
+  public void setGeneratedSourceDirs(Set<File> generatedSourceDirs) {
+    this.generatedSourceDirs = generatedSourceDirs;
+  }
+
+  @Override
+  public String getCompileTaskName() {
+    return compileTaskName;
+  }
+
+  public void setCompileTaskName(String compileTaskName) {
+    this.compileTaskName = compileTaskName;
+  }
+
+  @Override
+  public File getClassesDir() {
+    return classesDir;
+  }
+
+  public void setClassesDir(File classesDir) {
+    this.classesDir = classesDir;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceDirs, generatedSourceDirs, compileTaskName, classesDir);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    DefaultGroovyExtension other = (DefaultGroovyExtension) obj;
+    return Objects.equals(sourceDirs, other.sourceDirs)
+            && Objects.equals(generatedSourceDirs, other.generatedSourceDirs)
+            && Objects.equals(compileTaskName, other.compileTaskName)
+            && Objects.equals(classesDir, other.classesDir);
+  }
+  
+
+  @Override
+  public boolean isJavaExtension() {
+    return false;
+  }
+
+  @Override
+  public boolean isScalaExtension() {
+    return false;
+  }
+
+  @Override
+  public boolean isGroovyExtension() {
+    return true;
+  }
+
+  @Override
+  public JavaExtension getAsJavaExtension() {
+    return null;
+  }
+
+  @Override
+  public ScalaExtension getAsScalaExtension() {
+    return null;
+  }
+
+  @Override
+  public GroovyExtension getAsGroovyExtension() {
+    return this;
+  }
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGroovyLanguage.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGroovyLanguage.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model.impl;
+
+import com.microsoft.java.bs.gradle.model.GroovyExtension;
+import com.microsoft.java.bs.gradle.model.LanguageExtension;
+import com.microsoft.java.bs.gradle.model.SupportedLanguage;
+
+import java.util.Map;
+
+/**
+ * Default Groovy implementation of {@link SupportedLanguage}.
+ */
+public class DefaultGroovyLanguage implements SupportedLanguage<GroovyExtension> {
+  @Override
+  public String getBspName() {
+    return "groovy";
+  }
+
+  @Override
+  public String getGradleName() {
+    return "groovy";
+  }
+
+  @Override
+  public GroovyExtension getExtension(Map<String, LanguageExtension> extensions) {
+    LanguageExtension extension = extensions.get(getBspName());
+    if (extension == null) {
+      return null;
+    }
+    if (extension.isGroovyExtension()) {
+      return extension.getAsGroovyExtension();
+    }
+    throw new IllegalArgumentException(
+        "LanguageExtension: " + extension + " is not a GroovyExtension."
+    );
+  }
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultJavaExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultJavaExtension.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.java.bs.gradle.model.impl;
 
+import com.microsoft.java.bs.gradle.model.GroovyExtension;
 import com.microsoft.java.bs.gradle.model.JavaExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 
@@ -156,12 +157,22 @@ public class DefaultJavaExtension implements JavaExtension {
   }
 
   @Override
+  public boolean isGroovyExtension() {
+    return false;
+  }
+
+  @Override
   public JavaExtension getAsJavaExtension() {
     return this;
   }
 
   @Override
   public ScalaExtension getAsScalaExtension() {
+    return null;
+  }
+
+  @Override
+  public GroovyExtension getAsGroovyExtension() {
     return null;
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultScalaExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultScalaExtension.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.java.bs.gradle.model.impl;
 
+import com.microsoft.java.bs.gradle.model.GroovyExtension;
 import com.microsoft.java.bs.gradle.model.JavaExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 
@@ -156,6 +157,11 @@ public class DefaultScalaExtension implements ScalaExtension {
   }
 
   @Override
+  public boolean isGroovyExtension() {
+    return false;
+  }
+
+  @Override
   public JavaExtension getAsJavaExtension() {
     return null;
   }
@@ -163,5 +169,10 @@ public class DefaultScalaExtension implements ScalaExtension {
   @Override
   public ScalaExtension getAsScalaExtension() {
     return this;
+  }
+
+  @Override
+  public GroovyExtension getAsGroovyExtension() {
+    return null;
   }
 }

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/GroovyLanguageModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/GroovyLanguageModelBuilder.java
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.plugin;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
+import com.microsoft.java.bs.gradle.model.GroovyExtension;
+import com.microsoft.java.bs.gradle.model.SupportedLanguage;
+import com.microsoft.java.bs.gradle.model.impl.DefaultGroovyExtension;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.tasks.GroovySourceDirectorySet;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.AbstractCompile;
+import org.gradle.api.tasks.compile.GroovyCompile;
+import org.gradle.util.GradleVersion;
+
+import com.microsoft.java.bs.gradle.model.SupportedLanguages;
+
+/**
+ * The language model builder for Groovy language.
+ */
+public class GroovyLanguageModelBuilder extends LanguageModelBuilder {
+
+  @Override
+  public SupportedLanguage<GroovyExtension> getLanguage() {
+    return SupportedLanguages.GROOVY;
+  }
+
+  private Set<File> getSourceFolders(SourceSet sourceSet) {
+    if (GradleVersion.current().compareTo(GradleVersion.version("7.1")) >= 0) {
+      SourceDirectorySet sourceDirectorySet = sourceSet.getExtensions()
+              .findByType(GroovySourceDirectorySet.class);
+      return sourceDirectorySet == null ? Collections.emptySet() : sourceDirectorySet.getSrcDirs();
+    } else {
+      // there is no way pre-Gradle 7.1 to get the groovy source dirs separately from other
+      // languages.  Luckily source dirs from all languages are jumbled together in BSP,
+      // so we can just reply with all.
+      // resource dirs must be removed.
+      Set<File> allSource = sourceSet.getAllSource().getSrcDirs();
+      Set<File> allResource = sourceSet.getResources().getSrcDirs();
+      return allSource.stream().filter(dir -> !allResource.contains(dir))
+        .collect(Collectors.toSet());
+    }
+  }
+
+  private GroovyCompile getGroovyCompileTask(Project project, SourceSet sourceSet) {
+    return (GroovyCompile) getLanguageCompileTask(project, sourceSet);
+  }
+
+  @Override
+  public DefaultGroovyExtension getExtensionFor(Project project, SourceSet sourceSet,
+                                 Set<GradleModuleDependency> moduleDependencies) {
+    GroovyCompile groovyCompile = getGroovyCompileTask(project, sourceSet);
+    if (groovyCompile != null) {
+      DefaultGroovyExtension extension = new DefaultGroovyExtension();
+
+      extension.setCompileTaskName(groovyCompile.getName());
+
+      extension.setSourceDirs(getSourceFolders(sourceSet));
+      extension.setGeneratedSourceDirs(Collections.emptySet());
+      extension.setClassesDir(getClassesDir(groovyCompile));
+
+      return extension;
+    }
+    return null;
+  }
+
+  private File getClassesDir(AbstractCompile compile) {
+    if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) >= 0) {
+      return compile.getDestinationDirectory().get().getAsFile();
+    } else {
+      return compile.getDestinationDir();
+    }
+  }
+}

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -181,6 +181,8 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
           results.add(new JavaLanguageModelBuilder());
         } else if (language.equalsIgnoreCase(SupportedLanguages.SCALA.getBspName())) {
           results.add(new ScalaLanguageModelBuilder());
+        } else if (language.equalsIgnoreCase(SupportedLanguages.GROOVY.getBspName())) {
+          results.add(new GroovyLanguageModelBuilder());
         }
       }
     }

--- a/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPluginTest.java
+++ b/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPluginTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
+import com.microsoft.java.bs.gradle.model.GroovyExtension;
 import com.microsoft.java.bs.gradle.model.JavaExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
@@ -621,6 +622,65 @@ class GradleBuildServerPluginTest {
             gradleSourceSet.getSourceSetName())));
         assertTrue(scalaExtension.getClassesDir().toPath().endsWith(Paths.get("classes", "scala",
             gradleSourceSet.getSourceSetName())));
+      }
+    });
+  }
+
+  @ParameterizedTest(name = "testGroovyModelBuilder {0}")
+  @MethodSource("versionProvider")
+  void testGroovyModelBuilder(GradleVersion gradleVersion) throws IOException {
+    withSourceSets("groovy", gradleVersion, gradleSourceSets -> {
+      assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
+      for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {
+        assertEquals("groovy", gradleSourceSet.getProjectName());
+        assertEquals(":", gradleSourceSet.getProjectPath());
+        assertTrue(gradleSourceSet.getSourceSetName().equals("main")
+                || gradleSourceSet.getSourceSetName().equals("test"));
+        assertTrue(gradleSourceSet.getClassesTaskName().equals(":classes")
+                || gradleSourceSet.getClassesTaskName().equals(":testClasses"));
+        assertFalse(gradleSourceSet.getCompileClasspath().isEmpty());
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+                .anyMatch(file -> file.toPath().endsWith("java")));
+        assertTrue(gradleSourceSet.getSourceDirs().stream()
+                .anyMatch(file -> file.toPath().endsWith("groovy")));
+        // annotation processor dirs weren't auto created before 5.2
+        if (gradleVersion.compareTo(GradleVersion.version("5.2")) >= 0) {
+          assertEquals(1, gradleSourceSet.getGeneratedSourceDirs().size());
+        }
+        assertFalse(gradleSourceSet.getResourceDirs().isEmpty());
+        assertNotNull(gradleSourceSet.getSourceOutputDirs());
+        assertNotNull(gradleSourceSet.getResourceOutputDir());
+        assertNotNull(gradleSourceSet.getBuildTargetDependencies());
+        assertNotNull(gradleSourceSet.getModuleDependencies());
+        JavaExtension javaExtension = SupportedLanguages.JAVA.getExtension(gradleSourceSet);
+        assertNotNull(javaExtension);
+        assertNotNull(javaExtension.getJavaHome());
+        assertNotNull(javaExtension.getJavaVersion());
+
+        GroovyExtension groovyExtension = SupportedLanguages.GROOVY.getExtension(gradleSourceSet);
+        assertNotNull(groovyExtension);
+
+        // dirs not split by language before 4.0
+        if (gradleVersion.compareTo(GradleVersion.version("4.0")) >= 0) {
+          assertTrue(gradleSourceSet.getSourceOutputDirs().stream()
+              .anyMatch(file -> file.toPath().endsWith(Paths.get("classes", "java",
+              gradleSourceSet.getSourceSetName()))));
+          assertTrue(gradleSourceSet.getSourceOutputDirs().stream()
+              .anyMatch(file -> file.toPath().endsWith(Paths.get("classes", "groovy",
+              gradleSourceSet.getSourceSetName()))));
+          assertTrue(javaExtension.getClassesDir().toPath().endsWith(Paths.get("classes", "java",
+              gradleSourceSet.getSourceSetName())));
+          assertTrue(groovyExtension.getClassesDir().toPath().endsWith(
+              Paths.get("classes", "groovy", gradleSourceSet.getSourceSetName())));
+        } else {
+          assertTrue(gradleSourceSet.getSourceOutputDirs().stream()
+              .anyMatch(file -> file.toPath().endsWith(Paths.get("classes",
+              gradleSourceSet.getSourceSetName()))));
+          assertTrue(groovyExtension.getClassesDir().toPath().endsWith(Paths.get("classes",
+              gradleSourceSet.getSourceSetName())));
+          assertTrue(javaExtension.getClassesDir().toPath().endsWith(Paths.get("classes",
+              gradleSourceSet.getSourceSetName())));
+        }
       }
     });
   }

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -1795,13 +1795,13 @@ class BuildTargetServerIntegrationTest {
       passingTestParams.setData(passingScalaTestParams);
       TestResult passingTestResult = gradleBuildServer.buildTargetTest(passingTestParams).join();
       // Caveat - this may fail if using too high JDK version for SPOCK.
-      // Dependency `org.spockframework:spock-core:2.3-groovy-4.0` may need upgrading.
+      // Dependency `org.spockframework:spock-core:XXXX` may need upgrading.
       assertEquals(StatusCode.OK, passingTestResult.getStatusCode());
       assertEquals("originId", passingTestResult.getOriginId());
-      client.waitOnStartReports(4);
-      client.waitOnFinishReports(5);
-      client.waitOnCompileTasks(2);
-      client.waitOnCompileReports(2);
+      client.waitOnStartReports(6);
+      client.waitOnFinishReports(7);
+      client.waitOnCompileTasks(4);
+      client.waitOnCompileReports(4);
       client.waitOnLogMessages(0);
       client.waitOnTestStarts(2);
       client.waitOnTestFinishes(2);

--- a/testProjects/groovy/build.gradle
+++ b/testProjects/groovy/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+	id 'groovy'
+	id 'java-gradle-plugin'
+}

--- a/testProjects/groovy/settings.gradle
+++ b/testProjects/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groovy'


### PR DESCRIPTION
BSP doesn't have any specifics about Groovy so the details in the language model are just really the source directories.

I guess users can request more info if they need e.g. groovyCompileOptions but that would need BSP changes.

For now this will allow standard BSP commands to be used on groovy projects e.g. compile, test, run etc.