### PR TITLE
Add jdk 22 compatibility

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
@@ -149,7 +149,9 @@ public class Utils {
    */
   public static String getHighestCompatibleJavaVersion(String gradleVersion) {
     GradleVersion version = GradleVersion.version(gradleVersion);
-    if (version.compareTo(GradleVersion.version("8.5")) >= 0) {
+    if (version.compareTo(GradleVersion.version("8.7")) >= 0) {
+      return "22";
+    } else if (version.compareTo(GradleVersion.version("8.5")) >= 0) {
       return "21";
     } else if (version.compareTo(GradleVersion.version("8.3")) >= 0) {
       return "20";


### PR DESCRIPTION
Gradle supports JDK 22 from version 8.7

https://docs.gradle.org/current/userguide/compatibility.html