### PR TITLE
Ignore compilation on empty build targets

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -249,15 +249,19 @@ public class BuildTargetService {
    * Compile the build targets.
    */
   public CompileResult compile(CompileParams params) {
-    StatusCode code = runTasks(params.getTargets(), this::getBuildTaskName);
-    CompileResult result = new CompileResult(code);
-    result.setOriginId(params.getOriginId());
+    if (params.getTargets().isEmpty()) {
+      return new CompileResult(StatusCode.OK);
+    } else {
+      StatusCode code = runTasks(params.getTargets(), this::getBuildTaskName);
+      CompileResult result = new CompileResult(code);
+      result.setOriginId(params.getOriginId());
 
-    // Schedule a task to refetch the build targets after compilation, this is to
-    // auto detect the source roots changes for those code generation framework,
-    // such as Protocol Buffer.
-    CompletableFuture.runAsync(new RefetchBuildTargetTask());
-    return result;
+      // Schedule a task to refetch the build targets after compilation, this is to
+      // auto detect the source roots changes for those code generation framework,
+      // such as Protocol Buffer.
+      CompletableFuture.runAsync(new RefetchBuildTargetTask());
+      return result;
+    }
   }
 
   /**


### PR DESCRIPTION
There's no `alive` check in BSP so the client can repeatedly check that the server is still up and running.

Metals uses `buildTarget/compile` for this with an empty list of targets but this causes a complete refresh of all the source sets.

So this adds a guard so no refresh is done if the list of targets is empty.