### PR TITLE
Shift sourceset population out of buildInitialize

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/Launcher.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/Launcher.java
@@ -48,8 +48,7 @@ public class Launcher {
     BuildTargetManager buildTargetManager = new BuildTargetManager();
     PreferenceManager preferenceManager = new PreferenceManager();
     GradleApiConnector connector = new GradleApiConnector(preferenceManager);
-    LifecycleService lifecycleService = new LifecycleService(buildTargetManager,
-        connector, preferenceManager);
+    LifecycleService lifecycleService = new LifecycleService(connector, preferenceManager);
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
         connector, preferenceManager);
     GradleBuildServer gradleBuildServer = new GradleBuildServer(lifecycleService,

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
@@ -104,8 +104,10 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
 
   @Override
   public CompletableFuture<Object> workspaceReload() {
-    return handleRequest("workspace/reload", cc ->
-        lifecycleService.reloadWorkspace());
+    return handleRequest("workspace/reload", cc -> {
+      buildTargetService.reloadWorkspace();
+      return null;
+    });
   }
 
   @Override

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
@@ -19,13 +19,11 @@ import com.microsoft.java.bs.core.Constants;
 import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
 import com.microsoft.java.bs.core.internal.gradle.GradleBuildKind;
 import com.microsoft.java.bs.core.internal.gradle.Utils;
-import com.microsoft.java.bs.core.internal.managers.BuildTargetManager;
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
 import com.microsoft.java.bs.core.internal.model.Preferences;
 import com.microsoft.java.bs.core.internal.utils.JsonUtils;
 import com.microsoft.java.bs.core.internal.utils.TelemetryUtils;
 import com.microsoft.java.bs.core.internal.utils.UriUtils;
-import com.microsoft.java.bs.gradle.model.GradleSourceSets;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 
 import ch.epfl.scala.bsp4j.BuildServerCapabilities;
@@ -40,8 +38,6 @@ public class LifecycleService {
 
   private Status status = Status.UNINITIALIZED;
 
-  private BuildTargetManager buildTargetManager;
-
   private GradleApiConnector connector;
 
   private PreferenceManager preferenceManager;
@@ -49,9 +45,7 @@ public class LifecycleService {
   /**
    * Constructor for {@link LifecycleService}.
    */
-  public LifecycleService(BuildTargetManager buildTargetManager,
-      GradleApiConnector connector, PreferenceManager preferenceManager) {
-    this.buildTargetManager = buildTargetManager;
+  public LifecycleService(GradleApiConnector connector, PreferenceManager preferenceManager) {
     this.connector = connector;
     this.preferenceManager = preferenceManager;
   }
@@ -61,7 +55,6 @@ public class LifecycleService {
    */
   public InitializeBuildResult initializeServer(InitializeBuildParams params) {
     initializePreferenceManager(params);
-    updateBuildTargetManager();
 
     BuildServerCapabilities capabilities = initializeServerCapabilities();
     return new InitializeBuildResult(
@@ -70,11 +63,6 @@ public class LifecycleService {
         Constants.BSP_VERSION,
         capabilities
     );
-  }
-
-  public Object reloadWorkspace() {
-    updateBuildTargetManager();
-    return null;
   }
 
   void initializePreferenceManager(InitializeBuildParams params) {
@@ -90,12 +78,6 @@ public class LifecycleService {
 
     preferenceManager.setPreferences(preferences);
     updateGradleJavaHomeIfNecessary(rootUri);
-  }
-
-  void updateBuildTargetManager() {
-    GradleSourceSets sourceSets = connector.getGradleSourceSets(
-          preferenceManager.getRootUri());
-    buildTargetManager.store(sourceSets);
   }
 
   private BuildServerCapabilities initializeServerCapabilities() {

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -58,8 +58,7 @@ class BuildTargetServerIntegrationTest {
     BuildTargetManager buildTargetManager = new BuildTargetManager();
     PreferenceManager preferenceManager = new PreferenceManager();
     GradleApiConnector connector = new GradleApiConnector(preferenceManager);
-    LifecycleService lifecycleService = new LifecycleService(buildTargetManager,
-        connector, preferenceManager);
+    LifecycleService lifecycleService = new LifecycleService(connector, preferenceManager);
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
         connector, preferenceManager);
     gradleBuildServer = new GradleBuildServer(lifecycleService, buildTargetService);

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/LifecycleServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/LifecycleServiceTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import com.microsoft.java.bs.core.Constants;
 import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
-import com.microsoft.java.bs.core.internal.managers.BuildTargetManager;
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
 import com.microsoft.java.bs.core.internal.model.Preferences;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
@@ -44,7 +43,6 @@ class LifecycleServiceTest {
     );
 
     LifecycleService lifecycleService = mock(LifecycleService.class);
-    doNothing().when(lifecycleService).updateBuildTargetManager();
     doNothing().when(lifecycleService).initializePreferenceManager(any());
     when(lifecycleService.initializeServer(any())).thenCallRealMethod();
 
@@ -71,7 +69,7 @@ class LifecycleServiceTest {
     params.setData(preferences);
 
     PreferenceManager preferenceManager = new PreferenceManager();
-    LifecycleService lifecycleService = new LifecycleService(mock(BuildTargetManager.class),
+    LifecycleService lifecycleService = new LifecycleService(
         mock(GradleApiConnector.class), preferenceManager);
     lifecycleService.initializePreferenceManager(params);
 


### PR DESCRIPTION
Metals (BSP client) expects a prompt response to `build/initialize` and if it doesn't get one within 30 seconds it assumes the build server has not started correctly and so attempts to restart it.

Large projects take longer than this because the sourceset population takes a long time.

This shifts the population of sourcesets away from `build/initialize` and into `workspace/buildTargets`

It also shifts the responsibility of handling `workspace/reload` away from `LifecycleService` and into `BuildTargetService`.  The `LifecycleService` code was similar to that `RefetchBuildTargetTask` so this allows doing away with `RefetchBuildTargetTask` and also means that any call to `workspace/reload` will cause a `buildTarget/didChange` event if the workspace has changed - which wasn't the case before.

