### PR TITLE
add message checking to integration tests

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/Launcher.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/Launcher.java
@@ -23,8 +23,6 @@ import ch.epfl.scala.bsp4j.BuildClient;
  */
 public class Launcher {
 
-  public static BuildClient client;
-
   public static final Logger LOGGER = Logger.getLogger("GradleBuildServerLogger");
 
   /**
@@ -37,10 +35,9 @@ public class Launcher {
    */
   public static void main(String[] args) {
     checkRequiredProperties();
-    setupLoggers();
 
     org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> launcher = createLauncher();
-    client = launcher.getRemoteProxy();
+    setupLoggers(launcher.getRemoteProxy());
     launcher.startListening();
   }
 
@@ -53,13 +50,16 @@ public class Launcher {
         connector, preferenceManager);
     GradleBuildServer gradleBuildServer = new GradleBuildServer(lifecycleService,
         buildTargetService);
-    return new org.eclipse.lsp4j.jsonrpc.Launcher.Builder<BuildClient>()
-      .setOutput(System.out)
-      .setInput(System.in)
-      .setLocalService(gradleBuildServer)
-      .setRemoteInterface(BuildClient.class)
-      .setExecutorService(Executors.newCachedThreadPool())
-      .create();
+    org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> launcher =
+        new org.eclipse.lsp4j.jsonrpc.Launcher.Builder<BuildClient>()
+          .setOutput(System.out)
+          .setInput(System.in)
+          .setLocalService(gradleBuildServer)
+          .setRemoteInterface(BuildClient.class)
+          .setExecutorService(Executors.newCachedThreadPool())
+          .create();
+    buildTargetService.setClient(launcher.getRemoteProxy());
+    return launcher;
   }
 
   private static void checkRequiredProperties() {
@@ -68,14 +68,14 @@ public class Launcher {
     }
   }
 
-  private static void setupLoggers() {
+  private static void setupLoggers(BuildClient client) {
     LOGGER.setUseParentHandlers(false);
-    LogHandler logHandler = new LogHandler();
+    LogHandler logHandler = new LogHandler(client);
     logHandler.setLevel(Level.FINE);
     LOGGER.addHandler(logHandler);
 
     if (System.getProperty("disableServerTelemetry") == null) {
-      TelemetryHandler telemetryHandler = new TelemetryHandler();
+      TelemetryHandler telemetryHandler = new TelemetryHandler(client);
       telemetryHandler.setLevel(Level.INFO);
       LOGGER.addHandler(telemetryHandler);
     }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/log/LogHandler.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/log/LogHandler.java
@@ -10,8 +10,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-import com.microsoft.java.bs.core.Launcher;
-
+import ch.epfl.scala.bsp4j.BuildClient;
 import ch.epfl.scala.bsp4j.LogMessageParams;
 import ch.epfl.scala.bsp4j.MessageType;
 
@@ -20,13 +19,19 @@ import ch.epfl.scala.bsp4j.MessageType;
  */
 public class LogHandler extends Handler {
 
+  private final BuildClient client;
+
+  public LogHandler(BuildClient client) {
+    this.client = client;
+  }
+
   @Override
   public void publish(LogRecord logRecord) {
     Format formatter = new SimpleDateFormat("HH:mm:ss");
     String timestamp = formatter.format(new Date());
     String logMessage = String.format("[%s - %s] %s", logRecord.getLevel().getName(),
         timestamp, logRecord.getMessage());
-    Launcher.client.onBuildLogMessage(new LogMessageParams(
+    client.onBuildLogMessage(new LogMessageParams(
         convertLevelToMessageType(logRecord.getLevel()), logMessage));
   }
 

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/log/TelemetryHandler.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/log/TelemetryHandler.java
@@ -8,8 +8,8 @@ import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 
 import com.google.gson.Gson;
-import com.microsoft.java.bs.core.Launcher;
 
+import ch.epfl.scala.bsp4j.BuildClient;
 import ch.epfl.scala.bsp4j.LogMessageParams;
 import ch.epfl.scala.bsp4j.MessageType;
 
@@ -17,6 +17,12 @@ import ch.epfl.scala.bsp4j.MessageType;
  * The log appender to send bi data.
  */
 public class TelemetryHandler extends Handler {
+
+  private final BuildClient client;
+
+  public TelemetryHandler(BuildClient client) {
+    this.client = client;
+  }
 
   @Override
   public void publish(LogRecord logRecord) {
@@ -27,7 +33,7 @@ public class TelemetryHandler extends Handler {
     }
 
     String jsonStr = new Gson().toJson(property[0]);
-    Launcher.client.onBuildLogMessage(new LogMessageParams(MessageType.LOG, jsonStr));
+    client.onBuildLogMessage(new LogMessageParams(MessageType.LOG, jsonStr));
   }
 
   @Override

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/CompileProgressReporter.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/CompileProgressReporter.java
@@ -5,8 +5,6 @@ package com.microsoft.java.bs.core.internal.reporter;
 
 import java.util.UUID;
 
-import com.microsoft.java.bs.core.Launcher;
-
 import ch.epfl.scala.bsp4j.BuildClient;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.CompileReport;
@@ -23,52 +21,52 @@ import ch.epfl.scala.bsp4j.TaskStartParams;
  */
 public class CompileProgressReporter implements ProgressReporter {
 
-  private BuildTargetIdentifier btId;
+  private final BuildTargetIdentifier btId;
   private final TaskId taskId;
-  private BuildClient client;
+  private final BuildClient client;
 
   /**
    * Instantiates a {@link CompileProgressReporter}.
    *
    * @param btId Build target identifier
    */
-  public CompileProgressReporter(BuildTargetIdentifier btId) {
+  public CompileProgressReporter(BuildClient client, BuildTargetIdentifier btId) {
     this.btId = btId;
     this.taskId = new TaskId(UUID.randomUUID().toString());
-    client = Launcher.client;
+    this.client = client;
   }
 
   @Override
   public void taskStarted(String message) {
-    TaskStartParams startParam = new TaskStartParams(taskId);
-    startParam.setMessage(message);
-    startParam.setDataKind(TaskDataKind.COMPILE_TASK);
-    startParam.setData(new CompileTask(this.btId));
     if (client != null) {
+      TaskStartParams startParam = new TaskStartParams(taskId);
+      startParam.setMessage(message);
+      startParam.setDataKind(TaskDataKind.COMPILE_TASK);
+      startParam.setData(new CompileTask(this.btId));
       client.onBuildTaskStart(startParam);
     }
   }
 
   @Override
   public void taskInProgress(String message) {
-    TaskProgressParams progressParam = new TaskProgressParams(taskId);
-    progressParam.setMessage(message);
-    progressParam.setDataKind(TaskDataKind.COMPILE_TASK);
     if (client != null) {
+      TaskProgressParams progressParam = new TaskProgressParams(taskId);
+      progressParam.setMessage(message);
+      progressParam.setDataKind(TaskDataKind.COMPILE_TASK);
+      progressParam.setData(new CompileTask(this.btId));
       client.onBuildTaskProgress(progressParam);
     }
   }
 
   @Override
   public void taskFinished(String message, StatusCode statusCode) {
-    TaskFinishParams endParam = new TaskFinishParams(taskId, statusCode);
-    endParam.setMessage(message);
-    endParam.setDataKind(TaskDataKind.COMPILE_REPORT);
-    endParam.setData(new CompileReport(this.btId, 0, 0)); // TODO: parse the errors and warnings
     if (client != null) {
+      TaskFinishParams endParam = new TaskFinishParams(taskId, statusCode);
+      endParam.setMessage(message);
+      endParam.setDataKind(TaskDataKind.COMPILE_REPORT);
+      endParam.setData(new CompileReport(this.btId, 0, 0)); // TODO: parse the errors and warnings
       client.onBuildTaskFinish(endParam);
     }
-    client = null;
   }
 }
 

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/DefaultProgressReporter.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/DefaultProgressReporter.java
@@ -5,8 +5,6 @@ package com.microsoft.java.bs.core.internal.reporter;
 
 import java.util.UUID;
 
-import com.microsoft.java.bs.core.Launcher;
-
 import ch.epfl.scala.bsp4j.BuildClient;
 import ch.epfl.scala.bsp4j.StatusCode;
 import ch.epfl.scala.bsp4j.TaskFinishParams;
@@ -20,38 +18,37 @@ import ch.epfl.scala.bsp4j.TaskStartParams;
 public class DefaultProgressReporter implements ProgressReporter {
 
   private final TaskId taskId;
-  private BuildClient client;
+  private final BuildClient client;
 
-  public DefaultProgressReporter() {
+  public DefaultProgressReporter(BuildClient client) {
     this.taskId = new TaskId(UUID.randomUUID().toString());
-    client = Launcher.client;
+    this.client = client;
   }
 
   @Override
   public void taskStarted(String message) {
-    TaskStartParams startParam = new TaskStartParams(taskId);
-    startParam.setMessage(message);
     if (client != null) {
+      TaskStartParams startParam = new TaskStartParams(taskId);
+      startParam.setMessage(message);
       client.onBuildTaskStart(startParam);
     }
   }
 
   @Override
   public void taskInProgress(String message) {
-    TaskProgressParams progressParam = new TaskProgressParams(taskId);
-    progressParam.setMessage(message);
     if (client != null) {
+      TaskProgressParams progressParam = new TaskProgressParams(taskId);
+      progressParam.setMessage(message);
       client.onBuildTaskProgress(progressParam);
     }
   }
 
   @Override
   public void taskFinished(String message, StatusCode statusCode) {
-    TaskFinishParams endParam = new TaskFinishParams(taskId, statusCode);
-    endParam.setMessage(message);
     if (client != null) {
+      TaskFinishParams endParam = new TaskFinishParams(taskId, statusCode);
+      endParam.setMessage(message);
       client.onBuildTaskFinish(endParam);
     }
-    client = null;
   }
 }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -28,7 +28,6 @@ import com.microsoft.java.bs.gradle.model.JavaExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 import org.apache.commons.lang3.StringUtils;
 
-import com.microsoft.java.bs.core.Launcher;
 import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
 import com.microsoft.java.bs.core.internal.managers.BuildTargetManager;
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
@@ -40,6 +39,7 @@ import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 
+import ch.epfl.scala.bsp4j.BuildClient;
 import ch.epfl.scala.bsp4j.BuildTarget;
 import ch.epfl.scala.bsp4j.BuildTargetEvent;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
@@ -80,11 +80,13 @@ public class BuildTargetService {
 
   private static final String MAVEN_DATA_KIND = "maven";
 
-  private BuildTargetManager buildTargetManager;
+  private final BuildTargetManager buildTargetManager;
 
-  private GradleApiConnector connector;
+  private final GradleApiConnector connector;
 
-  private PreferenceManager preferenceManager;
+  private final PreferenceManager preferenceManager;
+
+  private BuildClient client;
 
   private boolean firstTime;
 
@@ -131,11 +133,16 @@ public class BuildTargetService {
         .map(BuildTargetEvent::new)
         .collect(Collectors.toList());
     DidChangeBuildTarget param = new DidChangeBuildTarget(events);
-    Launcher.client.onBuildTargetDidChange(param);
+    client.onBuildTargetDidChange(param);
   }
 
   private GradleBuildTarget getGradleBuildTarget(BuildTargetIdentifier btId) {
     return getBuildTargetManager().getGradleBuildTarget(btId);
+  }
+
+  public void setClient(BuildClient client) {
+    this.client = client;
+    connector.setClient(client);
   }
 
   /**

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -4,11 +4,22 @@
 package com.microsoft.java.bs.core.internal.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import ch.epfl.scala.bsp4j.DependencyModulesParams;
@@ -19,7 +30,6 @@ import ch.epfl.scala.bsp4j.MavenDependencyModule;
 import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.microsoft.java.bs.core.Launcher;
@@ -31,20 +41,133 @@ import com.microsoft.java.bs.core.internal.services.LifecycleService;
 import com.microsoft.java.bs.core.internal.utils.JsonUtils;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 
+import ch.epfl.scala.bsp4j.BuildClient;
 import ch.epfl.scala.bsp4j.BuildClientCapabilities;
+import ch.epfl.scala.bsp4j.BuildServer;
+import ch.epfl.scala.bsp4j.BuildTarget;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.CleanCacheParams;
 import ch.epfl.scala.bsp4j.CleanCacheResult;
 import ch.epfl.scala.bsp4j.CompileParams;
+import ch.epfl.scala.bsp4j.CompileReport;
 import ch.epfl.scala.bsp4j.CompileResult;
+import ch.epfl.scala.bsp4j.DidChangeBuildTarget;
 import ch.epfl.scala.bsp4j.InitializeBuildParams;
+import ch.epfl.scala.bsp4j.JavaBuildServer;
+import ch.epfl.scala.bsp4j.JvmBuildServer;
+import ch.epfl.scala.bsp4j.LogMessageParams;
+import ch.epfl.scala.bsp4j.PublishDiagnosticsParams;
+import ch.epfl.scala.bsp4j.ShowMessageParams;
 import ch.epfl.scala.bsp4j.StatusCode;
+import ch.epfl.scala.bsp4j.TaskFinishParams;
+import ch.epfl.scala.bsp4j.TaskProgressParams;
+import ch.epfl.scala.bsp4j.TaskStartParams;
 import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 
 // TODO: Move to a dedicated source set for integration tests
 class BuildTargetServerIntegrationTest {
 
-  private GradleBuildServer gradleBuildServer;
+  private interface TestServer extends BuildServer, JavaBuildServer, JvmBuildServer {
+  }
+
+  private static class TestClient implements BuildClient {
+
+    private final List<TaskStartParams> startReports = new ArrayList<>();
+    private final List<TaskFinishParams> finishReports = new ArrayList<>();
+    private final Set<CompileReport> compileReports = new HashSet<>();
+
+    void clearMessages() {
+      startReports.clear();
+      finishReports.clear();
+      compileReports.clear();
+    }
+
+    void waitOnMessages(int startMessagesSize,
+                        int finishMessagesSize,
+                        int compileReportsSize) {
+      // set to 5000ms because it seems reasonable
+      long timeoutMs = 5000;
+      long endTime = System.currentTimeMillis() + timeoutMs;
+      while ((startReports.size() < startMessagesSize
+              || finishReports.size() < finishMessagesSize
+              || compileReports.size() < compileReportsSize)
+              && System.currentTimeMillis() < endTime) {
+        synchronized (this) {
+          long waitTime = endTime - System.currentTimeMillis();
+          if (waitTime > 0) {
+            try {
+              wait(waitTime);
+            } catch (InterruptedException e) {
+              // do nothing
+            }
+          }
+        }
+      }
+      assertEquals(startMessagesSize, startReports.size(), "Start Report count error");
+      assertEquals(finishMessagesSize, finishReports.size(), "Finish Reports count error");
+      assertEquals(compileReportsSize, compileReports.size(), "Compile Reports count error");
+    }
+
+    private CompileReport findCompileReport(BuildTargetIdentifier btId) {
+      CompileReport compileReport = compileReports.stream()
+              .filter(report -> report.getTarget().equals(btId))
+              .findFirst()
+              .orElse(null);
+      assertNotNull(compileReport, () -> {
+        String availableTargets = compileReports.stream()
+                .map(report -> report.getTarget().toString())
+                .collect(Collectors.joining(", "));
+        return "Target not found " + btId + ". Available: " + availableTargets;
+      });
+      return compileReport;
+    }
+
+    @Override
+    public void onBuildShowMessage(ShowMessageParams params) {
+      // do nothing
+    }
+
+    @Override
+    public void onBuildLogMessage(LogMessageParams params) {
+      // do nothing
+    }
+
+    @Override
+    public void onBuildTaskStart(TaskStartParams params) {
+      startReports.add(params);
+      synchronized (this) {
+        notify();
+      }
+    }
+
+    @Override
+    public void onBuildTaskProgress(TaskProgressParams params) {
+      // do nothing
+    }
+
+    @Override
+    public void onBuildTaskFinish(TaskFinishParams params) {
+      if (params.getDataKind() != null) {
+        if (params.getDataKind().equals("compile-report")) {
+          compileReports.add(JsonUtils.toModel(params.getData(), CompileReport.class));
+        }
+      }
+      finishReports.add(params);
+      synchronized (this) {
+        notify();
+      }
+    }
+
+    @Override
+    public void onBuildPublishDiagnostics(PublishDiagnosticsParams params) {
+      // do nothing
+    }
+
+    @Override
+    public void onBuildTargetDidChange(DidChangeBuildTarget params) {
+      // do nothing
+    }
+  }
 
   @BeforeAll
   static void beforeClass() {
@@ -53,79 +176,157 @@ class BuildTargetServerIntegrationTest {
     System.setProperty(Launcher.PROP_PLUGIN_DIR, pluginDir);
   }
 
-  @BeforeEach
-  void setUp() {
-    BuildTargetManager buildTargetManager = new BuildTargetManager();
-    PreferenceManager preferenceManager = new PreferenceManager();
-    GradleApiConnector connector = new GradleApiConnector(preferenceManager);
-    LifecycleService lifecycleService = new LifecycleService(connector, preferenceManager);
-    BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-        connector, preferenceManager);
-    gradleBuildServer = new GradleBuildServer(lifecycleService, buildTargetService);
-  }
-
   @AfterAll
   static void afterClass() {
     System.clearProperty(Launcher.PROP_PLUGIN_DIR);
   }
 
-  @Test
-  void testServer() {
+  private InitializeBuildParams getInitializeBuildParams(String projectDir) {
     File root = Paths.get(
         System.getProperty("user.dir"),
         "..",
         "testProjects",
-        "junit5-jupiter-starter-gradle").toFile();
+        projectDir).toFile();
 
     BuildClientCapabilities capabilities =
         new BuildClientCapabilities(SupportedLanguages.allBspNames);
-    InitializeBuildParams params = new InitializeBuildParams(
+    return new InitializeBuildParams(
         "test-client",
         "0.1.0",
         "0.1.0",
         root.toURI().toString(),
         capabilities
     );
-    gradleBuildServer.buildInitialize(params).join();
-    gradleBuildServer.onBuildInitialized();
+  }
 
-    WorkspaceBuildTargetsResult buildTargetsResult = gradleBuildServer.workspaceBuildTargets()
-        .join();
-    assertEquals(2, buildTargetsResult.getTargets().size());
+  private void withNewTestServer(String project, BiConsumer<TestServer, TestClient> consumer) {
+    ExecutorService threadPool = Executors.newCachedThreadPool();
+    try (PipedInputStream clientIn = new PipedInputStream();
+        PipedOutputStream clientOut = new PipedOutputStream();
+        PipedInputStream serverIn = new PipedInputStream();
+        PipedOutputStream serverOut = new PipedOutputStream()) {
+      try {
+        clientIn.connect(serverOut);
+        clientOut.connect(serverIn);
+      } catch (IOException e) {
+        throw new IllegalStateException("Cannot setup streams", e);
+      }
+      // server
+      BuildTargetManager buildTargetManager = new BuildTargetManager();
+      PreferenceManager preferenceManager = new PreferenceManager();
+      GradleApiConnector connector = new GradleApiConnector(preferenceManager);
+      LifecycleService lifecycleService = new LifecycleService(connector, preferenceManager);
+      BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
+              connector, preferenceManager);
+      GradleBuildServer gradleBuildServer =
+              new GradleBuildServer(lifecycleService, buildTargetService);
+      org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> serverLauncher =
+              new org.eclipse.lsp4j.jsonrpc.Launcher.Builder<BuildClient>()
+                      .setLocalService(gradleBuildServer)
+                      .setRemoteInterface(BuildClient.class)
+                      .setOutput(serverOut)
+                      .setInput(serverIn)
+                      .setExecutorService(threadPool)
+                      .create();
+      buildTargetService.setClient(serverLauncher.getRemoteProxy());
+      // client
+      TestClient client = new TestClient();
+      org.eclipse.lsp4j.jsonrpc.Launcher<TestServer> clientLauncher =
+          new org.eclipse.lsp4j.jsonrpc.Launcher.Builder<TestServer>()
+              .setLocalService(client)
+              .setRemoteInterface(TestServer.class)
+              .setInput(clientIn)
+              .setOutput(clientOut)
+              .setExecutorService(threadPool)
+              .create();
+      // start
+      clientLauncher.startListening();
+      serverLauncher.startListening();
+      TestServer testServer = clientLauncher.getRemoteProxy();
+      try {
+        InitializeBuildParams params = getInitializeBuildParams(project);
+        testServer.buildInitialize(params).join();
+        testServer.onBuildInitialized();
+        consumer.accept(testServer, client);
+      } finally {
+        testServer.buildShutdown().join();
+        threadPool.shutdown();
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException("Error closing streams", e);
+    }
+  }
 
-    List<BuildTargetIdentifier> btIds = buildTargetsResult.getTargets().stream()
-        .map(target -> target.getId())
-        .collect(Collectors.toList());
-    CleanCacheParams cleanCacheParams = new CleanCacheParams(btIds);
-    CleanCacheResult cleanResult = gradleBuildServer.buildTargetCleanCache(cleanCacheParams).join();
-    assertTrue(cleanResult.getCleaned());
-    CompileParams compileParams = new CompileParams(btIds);
-    CompileResult compileResult = gradleBuildServer.buildTargetCompile(compileParams).join();
-    assertEquals(StatusCode.OK, compileResult.getStatusCode());
-
-    // check dependency sources
-    DependencySourcesParams dependencySourcesParams = new DependencySourcesParams(btIds);
-    DependencySourcesResult dependencySourcesResult = gradleBuildServer
-        .buildTargetDependencySources(dependencySourcesParams).join();
-    assertEquals(2, dependencySourcesResult.getItems().size());
-    List<String> allSources = dependencySourcesResult.getItems().stream()
-        .flatMap(item -> item.getSources().stream()).collect(Collectors.toList());
-    assertTrue(allSources.stream().anyMatch(source -> source.endsWith("-sources.jar")));
-
-    // check dependency modules
-    DependencyModulesParams dependencyModulesParams = new DependencyModulesParams(btIds);
-    DependencyModulesResult dependencyModulesResult = gradleBuildServer
-            .buildTargetDependencyModules(dependencyModulesParams).join();
-    assertEquals(2, dependencyModulesResult.getItems().size());
-    List<MavenDependencyModuleArtifact> allArtifacts = dependencyModulesResult.getItems().stream()
-            .flatMap(item -> item.getModules().stream())
-            .filter(dependencyModule -> "maven".equals(dependencyModule.getDataKind()))
-            .map(dependencyModule -> JsonUtils.toModel(dependencyModule.getData(),
-                MavenDependencyModule.class))
-            .flatMap(mavenDependencyModule -> mavenDependencyModule.getArtifacts().stream())
-            .filter(artifact -> "sources".equals(artifact.getClassifier()))
+  private BuildTargetIdentifier getBt(List<BuildTargetIdentifier> btIds,
+      String projectPathSection, String sourceSetName) {
+    String sourceSet = "?sourceset=" + sourceSetName;
+    List<BuildTargetIdentifier> matching = btIds.stream()
+            .filter(id -> id.getUri().contains(projectPathSection))
+            .filter(id -> id.getUri().endsWith(sourceSet))
             .collect(Collectors.toList());
-    assertTrue(allArtifacts.stream().anyMatch(artifact ->
-        artifact.getUri().endsWith("-sources.jar")));
+    assertFalse(matching.isEmpty(), () -> "Build Target " + projectPathSection
+            + " with source set " + sourceSetName + " not found in "
+            + btIds.stream().map(Object::toString).collect(Collectors.joining(", ")));
+    assertEquals(1, matching.size(), () -> "Too many Build Targets like " + projectPathSection
+            + " with source set " + sourceSetName + " found in "
+            + btIds.stream().map(Object::toString).collect(Collectors.joining(", ")));
+    return matching.get(0);
+  }
+
+  @Test
+  void testCompilingSingleProjectServer() {
+    withNewTestServer("junit5-jupiter-starter-gradle", (gradleBuildServer, client) -> {
+      // get targets
+      WorkspaceBuildTargetsResult buildTargetsResult = gradleBuildServer.workspaceBuildTargets()
+          .join();
+      List<BuildTargetIdentifier> btIds = buildTargetsResult.getTargets().stream()
+          .map(BuildTarget::getId)
+          .collect(Collectors.toList());
+      assertEquals(2, btIds.size());
+
+      // check dependency sources
+      DependencySourcesParams dependencySourcesParams = new DependencySourcesParams(btIds);
+      DependencySourcesResult dependencySourcesResult = gradleBuildServer
+          .buildTargetDependencySources(dependencySourcesParams).join();
+      assertEquals(2, dependencySourcesResult.getItems().size());
+      List<String> allSources = dependencySourcesResult.getItems().stream()
+          .flatMap(item -> item.getSources().stream()).collect(Collectors.toList());
+      assertTrue(allSources.stream().anyMatch(source -> source.endsWith("-sources.jar")));
+
+      // check dependency modules
+      DependencyModulesParams dependencyModulesParams = new DependencyModulesParams(btIds);
+      DependencyModulesResult dependencyModulesResult = gradleBuildServer
+              .buildTargetDependencyModules(dependencyModulesParams).join();
+      assertEquals(2, dependencyModulesResult.getItems().size());
+      List<MavenDependencyModuleArtifact> allArtifacts = dependencyModulesResult.getItems().stream()
+              .flatMap(item -> item.getModules().stream())
+              .filter(dependencyModule -> "maven".equals(dependencyModule.getDataKind()))
+              .map(dependencyModule -> JsonUtils.toModel(dependencyModule.getData(),
+                  MavenDependencyModule.class))
+              .flatMap(mavenDependencyModule -> mavenDependencyModule.getArtifacts().stream())
+              .filter(artifact -> "sources".equals(artifact.getClassifier()))
+              .collect(Collectors.toList());
+      assertTrue(allArtifacts.stream().anyMatch(artifact ->
+          artifact.getUri().endsWith("-sources.jar")));
+
+      // clean targets
+      CleanCacheParams cleanCacheParams = new CleanCacheParams(btIds);
+      CleanCacheResult cleanResult = gradleBuildServer
+          .buildTargetCleanCache(cleanCacheParams).join();
+      assertTrue(cleanResult.getCleaned());
+      client.waitOnMessages(2, 2, 1);
+      client.clearMessages();
+
+      // compile targets
+      CompileParams compileParams = new CompileParams(btIds);
+      CompileResult compileResult = gradleBuildServer.buildTargetCompile(compileParams).join();
+      assertEquals(StatusCode.OK, compileResult.getStatusCode());
+      client.waitOnMessages(2, 2, 1);
+      BuildTargetIdentifier testBt = getBt(btIds, "/junit5-jupiter-starter-gradle/", "test");
+      CompileReport compileReportTest = client.findCompileReport(testBt);
+      assertEquals(0, compileReportTest.getWarnings());
+      assertEquals(0, compileReportTest.getErrors());
+      client.clearMessages();
+    });
   }
 }


### PR DESCRIPTION
Currently the integration tests only handle direct replies to BSP messages e.g. `workspace/buildTargets` returns `WorkspaceBuildTargetsResult`

This PR allows monitoring of async messages e.g. `build/taskProgress` and adds tests for these.

It's the first step in testing progress reports per build target and eventually diagnostic reports.

It also gets rid of the global `Launcher.client` which I think is a good thing.

Also fixed: the `onBuildTaskProgress` notification has a `compile-task` data kind so `data` must contain a `CompileTask`