### PR TITLE
Remove the fallback Gradle version

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleBuildKind.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleBuildKind.java
@@ -22,9 +22,5 @@ public enum GradleBuildKind {
   /*
    * From the used TAPI.
    */
-  TAPI,
-  /**
-   * Temporarily fallback to the default Gradle version used by Buildship (7.4.2).
-   */
-  FALLBACK;
+  TAPI;
 }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
@@ -42,8 +42,6 @@ public class Utils {
    */
   private static final String GRADLE_USER_HOME = "GRADLE_USER_HOME";
 
-  private static final String DEFAULT_BUILDSHIP_GRADLE_VERSION = "7.4.2";
-
   /**
    * Get the Gradle connector for the project.
    *
@@ -74,9 +72,6 @@ public class Utils {
         break;
       case SPECIFIED_INSTALLATION:
         connector.useInstallation(getGradleHome(preferences.getGradleHome()));
-        break;
-      case FALLBACK:
-        connector.useGradleVersion(DEFAULT_BUILDSHIP_GRADLE_VERSION);
         break;
       default:
         connector.useBuildDistribution();
@@ -294,8 +289,6 @@ public class Utils {
       return GradleBuildKind.SPECIFIED_INSTALLATION;
     }
 
-    // TODO: Once we figure out why TAPI fails a lot, we can enable it.
-    // return GradleBuildKind.TAPI;
-    return GradleBuildKind.FALLBACK;
+    return GradleBuildKind.TAPI;
   }
 }


### PR DESCRIPTION
- No need to align with the Buildship embedded Gradle version.