### PR TITLE
Auto download toolchain in test project

### DIFF
--- a/testProjects/java-compilerargs-toolchain/settings.gradle
+++ b/testProjects/java-compilerargs-toolchain/settings.gradle
@@ -1,1 +1,4 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
 rootProject.name = 'java-compilerargs-toolchain'


### PR DESCRIPTION
Downloads jdk 17 toolchain if it's not setup locally.

Only for toolchain test