### PR TITLE
Support buildTarget/run

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Following BSP requests are supported in the current implementation:
 - `buildTarget/javacOptions`
 - `buildTarget/scalacOptions`
 - `buildTarget/test`
+- `buildTarget/run`
 - `workspace/buildTargets`
 - `workspace/reload`
 

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
@@ -29,6 +30,7 @@ import org.gradle.tooling.model.build.BuildEnvironment;
 import org.gradle.util.GradleVersion;
 
 import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
+import com.microsoft.java.bs.core.internal.reporter.AppRunReporter;
 import com.microsoft.java.bs.core.internal.reporter.CompileProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.DefaultProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.ProgressReporter;
@@ -223,6 +225,76 @@ public class GradleApiConnector {
     } catch (GradleConnectionException | IllegalStateException e) {
       reporter.sendError("Error running test classes: " + e.getMessage());
       statusCode = StatusCode.ERROR;
+    }
+
+    return statusCode;
+  }
+
+  /**
+   * request Gradle to run main class.
+   */
+  public StatusCode runMainClass(URI projectUri, String projectPath, String sourceSetName,
+      String className, Map<String, String> environmentVariables, List<String> jvmOptions,
+      List<String> arguments, BuildClient client, String originId,
+      CompileProgressReporter compileProgressReporter) {
+
+    StatusCode statusCode = StatusCode.OK;
+    String taskName = "buildServerRunApp";
+    try (AppRunReporter reporter = new AppRunReporter(client, originId, taskName)) {
+      try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
+        String execTask = "gradle.projectsEvaluated {\n"
+            + "  def proj = rootProject.findProject('" + projectPath + "')\n"
+            + "  if (proj != null) {\n"
+            + "    proj.getTasks().create('" + taskName + "', JavaExec.class, {\n"
+            + "      classpath = proj.sourceSets." + sourceSetName + ".runtimeClasspath\n"
+            + "      mainClass = '" + className + "'\n";
+        if (arguments != null && !arguments.isEmpty()) {
+          String args = arguments.stream().collect(Collectors.joining("','", "['", "']"));
+          execTask += "      args = " + args + "\n";
+        }
+        if (environmentVariables != null && !environmentVariables.isEmpty()) {
+          String envVars = environmentVariables.entrySet().stream()
+              .map(entry -> "'" + entry.getKey() + "':'" + entry.getValue() + "'")
+              .collect(Collectors.joining(",", "[", "]"));
+          execTask += "      environment = " + envVars + "\n";
+        }
+        if (jvmOptions != null && !jvmOptions.isEmpty()) {
+          String jvmArgs = jvmOptions.stream().collect(Collectors.joining("','", "['", "']"));
+          execTask += "      jvmArgs = " + jvmArgs + "\n";
+        }
+        execTask += "    })\n"
+            + "  }\n"
+            + "}\n";
+        File initScript = Utils.createInitScriptFile(execTask);
+        try {
+          BuildLauncher launcher = Utils
+              .getBuildLauncher(connection, preferenceManager.getPreferences())
+              .forTasks(taskName)
+              // TODO this is needed to feedback the main class stdOut/Err but it will also feedback
+              // Gradle stdOut/Err so reporter will report on any compile messages etc.
+              // Unsure how to filter those out.
+              .setStandardOutput(reporter.getStdOut())
+              .setStandardError(reporter.getStdErr())
+              // TODO BSP `run/readStdin` requires 2.2
+              //    .setStandardInput(reporter.getStdIn())
+              .addArguments("--init-script", initScript.getAbsolutePath())
+              .addProgressListener(reporter, OperationType.TASK);
+          if (compileProgressReporter != null) {
+            launcher.addProgressListener(compileProgressReporter, OperationType.TASK);
+          }
+          // run method is blocking
+          launcher.run();
+        } finally {
+          initScript.delete();
+        }
+      } catch (GradleConnectionException | IllegalStateException e) {
+        String message = String.join("\n", ExceptionUtils.getRootCauseStackTraceList(e));
+        reporter.sendError("Error running main class: " + message);
+        statusCode = StatusCode.ERROR;
+      }
+    } catch (IOException e) {
+      // caused by close the output stream, just simply log the error.
+      LOGGER.severe(e.getMessage());
     }
 
     return statusCode;

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
@@ -5,7 +5,9 @@ package com.microsoft.java.bs.core.internal.gradle;
 
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -301,5 +303,25 @@ public class Utils {
     }
 
     return GradleBuildKind.TAPI;
+  }
+
+  /**
+   * Create a temporary init.gradle script.
+   * Caller is responsible for file deletion.
+   *
+   * @param contents contents of script.
+   * @return the init.gradle file.
+   */
+  public static File createInitScriptFile(String contents) {
+    try {
+      File initScriptFile = File.createTempFile("init", ".gradle");
+      if (!initScriptFile.getParentFile().exists()) {
+        initScriptFile.getParentFile().mkdirs();
+      }
+      Files.write(initScriptFile.toPath(), contents.getBytes());
+      return initScriptFile;
+    } catch (IOException e) {
+      throw new IllegalStateException("Error creating init file", e);
+    }
   }
 }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
@@ -62,6 +62,7 @@ public class BuildTargetManager {
       BuildTargetCapabilities buildTargetCapabilities = new BuildTargetCapabilities();
       buildTargetCapabilities.setCanCompile(true);
       buildTargetCapabilities.setCanTest(true);
+      buildTargetCapabilities.setCanRun(true);
       BuildTarget bt = new BuildTarget(
           btId,
           tags,

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/AppRunReporter.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/AppRunReporter.java
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.core.internal.reporter;
+
+import org.gradle.tooling.events.FailureResult;
+import org.gradle.tooling.events.FinishEvent;
+import org.gradle.tooling.events.OperationResult;
+import org.gradle.tooling.events.ProgressEvent;
+import org.gradle.tooling.events.StartEvent;
+
+import ch.epfl.scala.bsp4j.BuildClient;
+import ch.epfl.scala.bsp4j.StatusCode;
+import ch.epfl.scala.bsp4j.TaskFinishParams;
+import ch.epfl.scala.bsp4j.TaskId;
+import ch.epfl.scala.bsp4j.TaskProgressParams;
+import ch.epfl.scala.bsp4j.TaskStartParams;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * An implementation of {@link ProgressReporter} to report on main class output.
+ */
+public class AppRunReporter extends ProgressReporter implements Closeable {
+
+  private final String taskName;
+  private final SysOutOutputStream stdOut;
+  private final SysErrOutputStream stdErr;
+
+  /**
+   * Instantiates a {@link AppRunReporter}.
+   *
+   * @param client BSP client to report to.
+   * @param originId BSP client origin Id.
+   * @param taskName the name of the task that runs the app.
+   */
+  public AppRunReporter(BuildClient client, String originId, String taskName) {
+    super(client, originId);
+    this.taskName = taskName;
+    stdOut = new SysOutOutputStream(client, originId, taskId);
+    stdErr = new SysErrOutputStream(client, originId, taskId);
+  }
+
+  public OutputStream getStdOut() {
+    return stdOut;
+  }
+
+  public OutputStream getStdErr() {
+    return stdErr;
+  }
+
+  @Override
+  public void statusChanged(ProgressEvent event) {
+    if (client != null) {
+      String taskPath = getTaskPath(event.getDescriptor());
+      if (taskPath != null && taskPath.contains(taskName)) {
+        TaskId taskId = getTaskId(taskPath);
+        if (event instanceof StartEvent) {
+          taskStarted(taskId, event.getDisplayName());
+        } else if (event instanceof FinishEvent) {
+          OperationResult result = ((FinishEvent) event).getResult();
+          StatusCode status = result instanceof FailureResult ? StatusCode.ERROR : StatusCode.OK;
+          taskFinished(taskId, event.getDisplayName(), status);
+        } else {
+          taskInProgress(taskId, event.getDisplayName());
+        }
+      }
+    }
+  }
+
+  private void taskStarted(TaskId taskId, String message) {
+    TaskStartParams startParam = new TaskStartParams(taskId);
+    startParam.setEventTime(System.currentTimeMillis());
+    startParam.setMessage(message);
+    client.onBuildTaskStart(startParam);
+  }
+
+  private void taskInProgress(TaskId taskId, String message) {
+    TaskProgressParams progressParam = new TaskProgressParams(taskId);
+    progressParam.setEventTime(System.currentTimeMillis());
+    progressParam.setMessage(message);
+    client.onBuildTaskProgress(progressParam);
+  }
+
+  private void taskFinished(TaskId taskId, String message,
+      StatusCode statusCode) {
+    TaskFinishParams endParam = new TaskFinishParams(taskId, statusCode);
+    endParam.setEventTime(System.currentTimeMillis());
+    endParam.setMessage(message);
+    client.onBuildTaskFinish(endParam);
+  }
+
+  @Override
+  public void close() throws IOException {
+    stdOut.close();
+    stdErr.close();
+  }
+}

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/SysErrOutputStream.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/SysErrOutputStream.java
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.core.internal.reporter;
+
+import ch.epfl.scala.bsp4j.BuildClient;
+import ch.epfl.scala.bsp4j.LogMessageParams;
+import ch.epfl.scala.bsp4j.MessageType;
+import ch.epfl.scala.bsp4j.TaskId;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Class to pass on system err from Gradle to Build Client.
+ */
+public class SysErrOutputStream extends OutputStream {
+
+  private final BuildClient client;
+  private final String originId;
+  private final TaskId taskId;
+  private final ByteArrayOutputStream out;
+
+  /**
+   * Instantiates a {@link SysErrOutputStream}.
+   *
+   * @param client BSP client to report to.
+   * @param originId id of the BSP client message.
+   * @param taskId taskId for the BSP request.
+   */
+  public SysErrOutputStream(BuildClient client, String originId, TaskId taskId) {
+    super();
+    this.client = client;
+    this.originId = originId;
+    this.taskId = taskId;
+    out = new ByteArrayOutputStream();
+  }
+
+  private void sendErr(String str) {
+    // TODO need to upgrade BSP version to get OnRunPrintStdErr
+    // for now send a log message
+    if (client != null) {
+      LogMessageParams params = new LogMessageParams(MessageType.ERROR, str);
+      params.setTask(taskId);
+      params.setOriginId(originId);
+      client.onBuildLogMessage(params);
+    }
+  }
+
+  @Override
+  public void write(final byte[] buf, final int off, final int len) {
+    out.write(buf, off, len);
+    sendErr(out.toString());
+    out.reset();
+  }
+
+  @Override
+  public void write(final int integer) {
+    out.write(integer);
+    sendErr(out.toString());
+    out.reset();
+  }
+
+  @Override
+  public void close() throws IOException {
+    out.close();
+  }
+}

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/SysOutOutputStream.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/SysOutOutputStream.java
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.core.internal.reporter;
+
+import ch.epfl.scala.bsp4j.BuildClient;
+import ch.epfl.scala.bsp4j.LogMessageParams;
+import ch.epfl.scala.bsp4j.MessageType;
+import ch.epfl.scala.bsp4j.TaskId;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Class to pass on system out from Gradle to Build Client.
+ */
+public class SysOutOutputStream extends OutputStream {
+
+  private final BuildClient client;
+  private final String originId;
+  private final TaskId taskId;
+  private final ByteArrayOutputStream out;
+
+  /**
+   * Instantiates a {@link SysOutOutputStream}.
+   *
+   * @param client BSP client to report to.
+   * @param originId id of the BSP client message.
+   * @param taskId taskId for the BSP request.
+   */
+  public SysOutOutputStream(BuildClient client, String originId, TaskId taskId) {
+    super();
+    this.client = client;
+    this.originId = originId;
+    this.taskId = taskId;
+    out = new ByteArrayOutputStream();
+  }
+
+  private void sendOut(String str) {
+    // TODO need to upgrade BSP version to get OnRunPrintStdOut
+    // for now send a log message
+    if (client != null) {
+      LogMessageParams params = new LogMessageParams(MessageType.INFORMATION, str);
+      params.setTask(taskId);
+      params.setOriginId(originId);
+      client.onBuildLogMessage(params);
+    }
+  }
+
+  @Override
+  public void write(final byte[] buf, final int off, final int len) {
+    out.write(buf, off, len);
+    sendOut(out.toString());
+    out.reset();
+  }
+
+  @Override
+  public void write(final int integer) {
+    out.write(integer);
+    sendOut(out.toString());
+    out.reset();
+  }
+
+  @Override
+  public void close() throws IOException {
+    out.close();
+  }
+}

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
@@ -65,9 +65,9 @@ import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
  */
 public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBuildServer {
 
-  private LifecycleService lifecycleService;
+  private final LifecycleService lifecycleService;
 
-  private BuildTargetService buildTargetService;
+  private final BuildTargetService buildTargetService;
 
   public GradleBuildServer(LifecycleService lifecycleService,
       BuildTargetService buildTargetService) {
@@ -154,8 +154,7 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
 
   @Override
   public CompletableFuture<RunResult> buildTargetRun(RunParams params) {
-    // TODO Auto-generated method stub
-    throw new UnsupportedOperationException("Unimplemented method 'buildTargetRun'");
+    return handleRequest("buildTarget/run", cc -> buildTargetService.buildTargetRun(params));
   }
 
   @Override

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -64,6 +64,10 @@ import ch.epfl.scala.bsp4j.OutputPathsResult;
 import ch.epfl.scala.bsp4j.ResourcesItem;
 import ch.epfl.scala.bsp4j.ResourcesParams;
 import ch.epfl.scala.bsp4j.ResourcesResult;
+import ch.epfl.scala.bsp4j.RunParams;
+import ch.epfl.scala.bsp4j.RunParamsDataKind;
+import ch.epfl.scala.bsp4j.RunResult;
+import ch.epfl.scala.bsp4j.ScalaMainClass;
 import ch.epfl.scala.bsp4j.ScalaTestClassesItem;
 import ch.epfl.scala.bsp4j.ScalaTestParams;
 import ch.epfl.scala.bsp4j.ScalaTestSuiteSelection;
@@ -560,6 +564,56 @@ public class BuildTargetService {
       }
     }
     return testResult;
+  }
+
+  /**
+   * Run the main class.
+   */
+  public RunResult buildTargetRun(RunParams params) {
+    RunResult runResult = new RunResult(StatusCode.OK);
+    runResult.setOriginId(params.getOriginId());
+    if (!RunParamsDataKind.SCALA_MAIN_CLASS.equals(params.getDataKind())) {
+      LOGGER.warning("Run Data Kind " + params.getDataKind() + " not supported");
+      runResult.setStatusCode(StatusCode.ERROR);
+    } else {
+      // running tests can trigger compilation that must be reported on
+      CompileProgressReporter compileProgressReporter = new CompileProgressReporter(client,
+              params.getOriginId(), getFullTaskPathMap());
+      GradleBuildTarget buildTarget = getGradleBuildTarget(params.getTarget());
+      if (buildTarget == null) {
+        // TODO: https://github.com/microsoft/build-server-for-gradle/issues/50
+        throw new IllegalArgumentException("The build target does not exist: "
+          + params.getTarget().getUri());
+      }
+      URI projectUri = getRootProjectUri(params.getTarget());
+      // ideally BSP would have a jvmRunEnv style runkind for executing tests, not scala.
+      ScalaMainClass mainClass = JsonUtils.toModel(params.getData(), ScalaMainClass.class);
+      // TODO BSP is not clear on which argument set takes precedence
+      List<String> arguments1 = params.getArguments();
+      List<String> arguments2 = mainClass.getArguments();
+      List<String> argumentsToUse;
+      if (arguments1 == null || arguments1.isEmpty()) {
+        argumentsToUse = arguments2;
+      } else {
+        argumentsToUse = arguments1;
+      }
+      // TODO upgrade to later BSP version and then env vars can be passed to runMainClass
+      StatusCode statusCode = connector.runMainClass(projectUri,
+              buildTarget.getSourceSet().getProjectPath(),
+              buildTarget.getSourceSet().getSourceSetName(),
+              mainClass.getClassName(),
+              null,
+              mainClass.getJvmOptions(),
+              argumentsToUse,
+              client,
+              params.getOriginId(),
+              compileProgressReporter);
+
+      if (statusCode != StatusCode.OK) {
+        runResult.setStatusCode(statusCode);
+      }
+    }
+    return runResult;
   }
 
   /**

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -15,6 +15,7 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -49,6 +50,10 @@ import ch.epfl.scala.bsp4j.MavenDependencyModule;
 import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
 import ch.epfl.scala.bsp4j.MessageType;
 import ch.epfl.scala.bsp4j.PublishDiagnosticsParams;
+import ch.epfl.scala.bsp4j.RunParams;
+import ch.epfl.scala.bsp4j.RunParamsDataKind;
+import ch.epfl.scala.bsp4j.RunResult;
+import ch.epfl.scala.bsp4j.ScalaMainClass;
 import ch.epfl.scala.bsp4j.ScalaTestClassesItem;
 import ch.epfl.scala.bsp4j.ScalaTestParams;
 import ch.epfl.scala.bsp4j.ScalaTestSuiteSelection;
@@ -1273,6 +1278,63 @@ class BuildTargetServerIntegrationTest {
       for (TaskFinishParams message : client.finishReports) {
         assertEquals(StatusCode.OK, message.getStatus());
       }
+      client.clearMessages();
+    });
+  }
+
+  @Test
+  void testCleanStraightToRun() {
+    withNewTestServer("junit5-jupiter-starter-gradle", (gradleBuildServer, client) -> {
+      // get targets
+      WorkspaceBuildTargetsResult buildTargetsResult = gradleBuildServer.workspaceBuildTargets()
+          .join();
+      List<BuildTargetIdentifier> btIds = buildTargetsResult.getTargets().stream()
+          .map(BuildTarget::getId)
+          .collect(Collectors.toList());
+
+      // clean targets
+      CleanCacheParams cleanCacheParams = new CleanCacheParams(btIds);
+      gradleBuildServer.buildTargetCleanCache(cleanCacheParams).join();
+      client.clearMessages();
+
+      // a request to run mainClass straight after a clean should produce compile results/reports
+      // run main
+      ScalaMainClass mainClass = new ScalaMainClass("com.example.project.Calculator",
+          Collections.emptyList(), Collections.emptyList());
+      BuildTargetIdentifier btId = findTarget(buildTargetsResult.getTargets(),
+            "junit5-jupiter-starter-gradle [main]");
+      RunParams runParams = new RunParams(btId);
+      runParams.setOriginId("originId");
+      runParams.setDataKind(RunParamsDataKind.SCALA_MAIN_CLASS);
+      runParams.setData(mainClass);
+      RunResult runResult = gradleBuildServer.buildTargetRun(runParams).join();
+      assertEquals("originId", runResult.getOriginId());
+      client.waitOnStartReports(2);
+      client.waitOnFinishReports(2);
+      client.waitOnCompileTasks(1);
+      client.waitOnCompileReports(1);
+      // TODO change after upgrade to BSP 2.2 and switch to run/printStdout and run/printStderr
+      client.waitOnLogMessages(22);
+      client.waitOnTestStarts(0);
+      client.waitOnTestFinishes(0);
+      client.waitOnTestReports(0);
+      // TODO- switch to checking run/printStderr messages
+      assertTrue(client.logMessages.stream().anyMatch(message ->
+          message.getType() == MessageType.ERROR
+          && message.getMessage().equals("Syserr test")));
+      // TODO- switch to checking run/printStdout messages
+      assertTrue(client.logMessages.stream().anyMatch(message ->
+          message.getType() == MessageType.INFORMATION
+          && message.getMessage().equals("Sysout test")));
+      for (CompileReport message : client.compileReports) {
+        assertFalse(message.getNoOp());
+      }
+      for (TaskFinishParams message : client.finishReports) {
+        assertEquals(StatusCode.OK, message.getStatus());
+      }
+      assertEquals(StatusCode.OK, runResult.getStatusCode(),
+          () -> client.finishReports.stream().map(TaskFinishParams::getMessage)
+                    .collect(Collectors.joining("\n")));
       client.clearMessages();
     });
   }

--- a/testProjects/junit5-jupiter-starter-gradle/src/main/java/com/example/project/Calculator.java
+++ b/testProjects/junit5-jupiter-starter-gradle/src/main/java/com/example/project/Calculator.java
@@ -10,10 +10,40 @@
 
 package com.example.project;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
 public class Calculator {
 
-	public int add(int a, int b) {
-		return a + b;
-	}
+  public int add(int a, int b) {
+    return a + b;
+  }
 
+
+  public static void main(String[] args) {
+    // TODO wait until upgrade of BSP 2.2 and support for OnRunReadStdin then uncomment
+    // and handle in integ tests
+    /*
+    if (args.length != 1) {
+      System.out.println("Requires 1 arg");
+      System.exit(1);
+    }*/
+    System.out.println("Sysout test");
+    System.err.println("Syserr test");
+    // TODO wait until upgrade of BSP 2.2 and support for OnRunReadStdin then uncomment
+    /*try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+      String input = br.readLine();
+      String requiredInput = args[0];
+      if (requiredInput.equals(input)) {
+        System.out.println("OK!");
+        System.err.println("No error");
+      } else  {
+        System.err.println("Expected [" + requiredInput + "] but got [" + input + "]");
+      }
+    } catch (IOException e) {
+      System.err.println("I/O Error getting string" + e);
+      System.exit(1);
+    }*/
+  }
 }


### PR DESCRIPTION
Allows running of `main` methods using `buildTarget/run` BSP request

Supports [`scala-main-class`](https://build-server-protocol.github.io/docs/extensions/scala#scalamainclass) `RunParamsDataKind` as there is no jvm specific data type.

Caveats...
1. StdIn - not connected since `run/readStdin` not supported - need to upgrade BSP to 2.2
2. StdOut - sent as log message since `run/printStdout` not supported - need to upgrade BSP to 2.2
3. StdErr - sent as log message since `run/printStderr` not supported - need to upgrade BSP to 2.2
4. Env vars are not passed -  need to upgrade BSP to 2.2
