### PR TITLE
Update Gradle tooling API to 8.7

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -266,7 +266,7 @@ END OF TERMS AND CONDITIONS
 
 ---------------------------------------------------------
 
-org.gradle/gradle-tooling-api - 8.1.1 - Apache-2.0
+org.gradle/gradle-tooling-api - 8.7 - Apache-2.0
 
                                  Apache License
                            Version 2.0, January 2004

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':model')
-    implementation 'org.gradle:gradle-tooling-api:8.1.1'
+    implementation 'org.gradle:gradle-tooling-api:8.7'
     implementation 'ch.epfl.scala:bsp4j:2.1.0-M4'
     implementation 'org.apache.commons:commons-lang3:3.13.0'
 

--- a/server/src/main/resources/NOTICE.txt
+++ b/server/src/main/resources/NOTICE.txt
@@ -1551,7 +1551,7 @@ END OF TERMS AND CONDITIONS
 
 ---------------------------------------------------------
 
-org.gradle/gradle-tooling-api - 8.1.1 - Apache-2.0
+org.gradle/gradle-tooling-api - 8.7 - Apache-2.0
 
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
Allows running tests under jdk 21 see [matrix](https://docs.gradle.org/current/userguide/compatibility.html)

License is still Apache 2.0

