### PR TITLE
Update BSP to 2.2.0-M2

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':model')
-    implementation 'ch.epfl.scala:bsp4j:2.1.0-M4'
+    implementation 'ch.epfl.scala:bsp4j:2.2.0-M2'
     implementation 'org.apache.commons:commons-lang3:3.13.0'
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))

--- a/server/src/main/java/ch/epfl/scala/bsp4j/extended/JvmBuildTargetEx.java
+++ b/server/src/main/java/ch/epfl/scala/bsp4j/extended/JvmBuildTargetEx.java
@@ -17,19 +17,17 @@ public class JvmBuildTargetEx extends JvmBuildTarget {
 
   private String targetCompatibility;
 
-  public JvmBuildTargetEx(String javaHome, String javaVersion) {
-    super(javaHome, javaVersion);
-  }
-
   /**
    * Create a new instance of {@link JvmBuildTargetEx}.
    */
   public JvmBuildTargetEx(String javaHome, String javaVersion,
       String gradleVersion, String sourceCompatibility, String targetCompatibility) {
-    super(javaHome, javaVersion);
+    super();
     this.gradleVersion = gradleVersion;
     this.sourceCompatibility = sourceCompatibility;
     this.targetCompatibility = targetCompatibility;
+    setJavaHome(javaHome);
+    setJavaVersion(javaVersion);
   }
 
   public String getGradleVersion() {

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/log/LogHandler.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/log/LogHandler.java
@@ -51,7 +51,7 @@ public class LogHandler extends Handler {
     } else if (Level.WARNING.equals(level)) {
       return MessageType.WARNING;
     } else {
-      return MessageType.INFORMATION;
+      return MessageType.INFO;
     }
   }
 }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/CompileProgressReporter.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/CompileProgressReporter.java
@@ -12,10 +12,11 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.CompileReport;
 import ch.epfl.scala.bsp4j.CompileTask;
 import ch.epfl.scala.bsp4j.StatusCode;
-import ch.epfl.scala.bsp4j.TaskDataKind;
+import ch.epfl.scala.bsp4j.TaskFinishDataKind;
 import ch.epfl.scala.bsp4j.TaskFinishParams;
 import ch.epfl.scala.bsp4j.TaskId;
 import ch.epfl.scala.bsp4j.TaskProgressParams;
+import ch.epfl.scala.bsp4j.TaskStartDataKind;
 import ch.epfl.scala.bsp4j.TaskStartParams;
 
 import org.gradle.tooling.events.FailureResult;
@@ -84,7 +85,7 @@ public class CompileProgressReporter extends ProgressReporter {
       TaskStartParams startParam = new TaskStartParams(taskId);
       startParam.setEventTime(eventTime);
       startParam.setMessage(message);
-      startParam.setDataKind(TaskDataKind.COMPILE_TASK);
+      startParam.setDataKind(TaskStartDataKind.COMPILE_TASK);
       startParam.setData(new CompileTask(btId));
       client.onBuildTaskStart(startParam);
     });
@@ -96,8 +97,6 @@ public class CompileProgressReporter extends ProgressReporter {
       TaskProgressParams progressParam = new TaskProgressParams(taskId);
       progressParam.setEventTime(eventTime);
       progressParam.setMessage(message);
-      progressParam.setDataKind(TaskDataKind.COMPILE_TASK);
-      progressParam.setData(new CompileTask(btId));
       client.onBuildTaskProgress(progressParam);
     });
   }
@@ -109,7 +108,7 @@ public class CompileProgressReporter extends ProgressReporter {
       TaskFinishParams endParam = new TaskFinishParams(taskId, statusCode);
       endParam.setEventTime(eventTime);
       endParam.setMessage(message);
-      endParam.setDataKind(TaskDataKind.COMPILE_REPORT);
+      endParam.setDataKind(TaskFinishDataKind.COMPILE_REPORT);
       // TODO Gradle > 8.8 Problems API will allow errors/warnings to be reported on
       CompileReport compileReport = new CompileReport(btId, 0, 0);
       compileReport.setNoOp(noOp);

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
@@ -43,6 +43,7 @@ import ch.epfl.scala.bsp4j.JavacOptionsParams;
 import ch.epfl.scala.bsp4j.JavacOptionsResult;
 import ch.epfl.scala.bsp4j.OutputPathsParams;
 import ch.epfl.scala.bsp4j.OutputPathsResult;
+import ch.epfl.scala.bsp4j.ReadParams;
 import ch.epfl.scala.bsp4j.ResourcesParams;
 import ch.epfl.scala.bsp4j.ResourcesResult;
 import ch.epfl.scala.bsp4j.RunParams;
@@ -162,6 +163,12 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
   public CompletableFuture<DebugSessionAddress> debugSessionStart(DebugSessionParams params) {
     // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'debugSessionStart'");
+  }
+
+  @Override
+  public void onRunReadStdin(ReadParams params) {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'onRunReadStdin'");
   }
 
   @Override

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -364,7 +364,7 @@ public class BuildTargetService {
   public CleanCacheResult cleanCache(CleanCacheParams params) {
     ProgressReporter reporter = new DefaultProgressReporter(client);
     StatusCode code = runTasks(params.getTargets(), this::getCleanTaskName, reporter);
-    return new CleanCacheResult(null, code == StatusCode.OK);
+    return new CleanCacheResult(code == StatusCode.OK);
   }
 
   /**

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -48,6 +48,7 @@ import ch.epfl.scala.bsp4j.LogMessageParams;
 import ch.epfl.scala.bsp4j.MavenDependencyModule;
 import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
 import ch.epfl.scala.bsp4j.MessageType;
+import ch.epfl.scala.bsp4j.PrintParams;
 import ch.epfl.scala.bsp4j.PublishDiagnosticsParams;
 import ch.epfl.scala.bsp4j.ScalaTestClassesItem;
 import ch.epfl.scala.bsp4j.ScalaTestParams;
@@ -284,6 +285,16 @@ class BuildTargetServerIntegrationTest {
 
     @Override
     public void onBuildTargetDidChange(DidChangeBuildTarget params) {
+      // do nothing
+    }
+
+    @Override
+    public void onRunPrintStdout(PrintParams params) {
+      // do nothing
+    }
+
+    @Override
+    public void onRunPrintStderr(PrintParams params) {
       // do nothing
     }
   }

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -79,7 +79,7 @@ class BuildTargetServiceTest {
     BuildTarget target = mock(BuildTarget.class);
     when(target.getBaseDirectory()).thenReturn("foo/bar");
     when(target.getDataKind()).thenReturn("jvm");
-    when(target.getData()).thenReturn(new JvmBuildTarget(null, null));
+    when(target.getData()).thenReturn(new JvmBuildTarget());
     GradleBuildTarget gradleBuildTarget = new GradleBuildTarget(target,
         mock(GradleSourceSet.class));
     when(buildTargetManager.getAllGradleBuildTargets())


### PR DESCRIPTION
1. Constructor parameter changes.
2. New interface methods.
3. `MessageType.INFORMATION` renamed to `MessageType.INFO`
4. `TaskDataKind` deprecation and replacement with `TaskStartDataKind` & `TaskFinishDataKind`.  No equivalent for `TaskProgressParams` but this wasn't really used by us so I've removed it.