### PR TITLE
LanguageExtension downcast resolution

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,5 +3,5 @@ java {
 }
 
 dependencies {
-  implementation 'org.gradle:gradle-tooling-api:8.7'
+  implementation 'org.gradle:gradle-tooling-api:8.8'
 }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,7 +1,3 @@
 java {
   sourceCompatibility = JavaVersion.VERSION_1_8
 }
-
-dependencies {
-  implementation 'org.gradle:gradle-tooling-api:8.8'
-}

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,3 +1,7 @@
 java {
   sourceCompatibility = JavaVersion.VERSION_1_8
 }
+
+dependencies {
+  implementation 'org.gradle:gradle-tooling-api:8.7'
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/LanguageExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/LanguageExtension.java
@@ -3,25 +3,52 @@
 
 package com.microsoft.java.bs.gradle.model;
 
-import org.gradle.internal.impldep.javax.annotation.Nullable;
-
 import java.io.Serializable;
 
 /**
- * parent interface for language extensions.
+ * Interface representing a language extension.
+ *
+ * @see JavaExtension
+ * @see ScalaExtension
  */
 public interface LanguageExtension extends Serializable {
 
-  @Nullable
+  /**
+   * Checks if the implementing class is a {@link JavaExtension}.
+   *
+   * @return true if the extension is for Java, false otherwise.
+   */
   boolean isJavaExtension();
 
-  @Nullable
+  /**
+   * Checks if the implementing class is a {@link ScalaExtension}.
+   *
+   * @return true if the extension is for Scala, false otherwise.
+   */
   boolean isScalaExtension();
 
-  @Nullable
+  /**
+   * Attempts to cast the current object to a {@link JavaExtension} instance.
+   * <p>
+   * This method should ideally be used only when the implementing class
+   * is known to be a {@link JavaExtension}.
+   * </p>
+   *
+   * @return the current object cast to a {@link JavaExtension} instance,
+   *        or null if the cast fails.
+   */
   JavaExtension getAsJavaExtension();
 
-  @Nullable
+  /**
+   * Attempts to cast the current object to a {@link ScalaExtension} instance.
+   * <p>
+   * This method should ideally be used only when the implementing class
+   * is known to be a {@link ScalaExtension}.
+   * </p>
+   *
+   * @return the current object cast to a {@link ScalaExtension} instance,
+   *        or null if the cast fails.
+   */
   ScalaExtension getAsScalaExtension();
 
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/LanguageExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/LanguageExtension.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.java.bs.gradle.model;
 
+import org.gradle.internal.impldep.javax.annotation.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -10,10 +12,16 @@ import java.io.Serializable;
  */
 public interface LanguageExtension extends Serializable {
 
-  /**
-   * clones a language extension.
-   * needed for conversion across classloaders.
-   * must return Object.
-   */
-  Object convert(ClassLoader classLoader);
+  @Nullable
+  boolean isJavaExtension();
+
+  @Nullable
+  boolean isScalaExtension();
+
+  @Nullable
+  JavaExtension getAsJavaExtension();
+
+  @Nullable
+  ScalaExtension getAsScalaExtension();
+
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -96,7 +96,15 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
   }
 
   private LanguageExtension convertLanguageExtension(LanguageExtension object) {
-    return (LanguageExtension) object.convert(getClass().getClassLoader());
+    if (object.isJavaExtension()) {
+      return object.getAsJavaExtension();
+    }
+
+    if (object.isScalaExtension()) {
+      return object.getAsScalaExtension();
+    }
+
+    throw new IllegalArgumentException("No conversion methods defined for object: " + object);
   }
 
   @Override

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultJavaExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultJavaExtension.java
@@ -4,9 +4,9 @@
 package com.microsoft.java.bs.gradle.model.impl;
 
 import com.microsoft.java.bs.gradle.model.JavaExtension;
+import com.microsoft.java.bs.gradle.model.ScalaExtension;
 
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,29 +25,6 @@ public class DefaultJavaExtension implements JavaExtension {
   private String targetCompatibility;
 
   private List<String> compilerArgs;
-
-  @Override
-  public Object convert(ClassLoader classLoader) {
-    try {
-      Class<?> destinationClass = classLoader.loadClass(getClass().getName());
-      Object result = destinationClass.getConstructor().newInstance();
-      destinationClass.getDeclaredMethod("setJavaHome", File.class)
-          .invoke(result, getJavaHome());
-      destinationClass.getDeclaredMethod("setJavaVersion", String.class)
-          .invoke(result, getJavaVersion());
-      destinationClass.getDeclaredMethod("setSourceCompatibility", String.class)
-          .invoke(result, getSourceCompatibility());
-      destinationClass.getDeclaredMethod("setTargetCompatibility", String.class)
-          .invoke(result, getTargetCompatibility());
-      destinationClass.getDeclaredMethod("setCompilerArgs", List.class)
-          .invoke(result, getCompilerArgs());
-      return result;
-    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
-              | NoSuchMethodException | ClassNotFoundException | InstantiationException
-              | SecurityException e) {
-      throw new IllegalStateException("Error converting " + getClass().getName(), e);
-    }
-  }
 
   @Override
   public File getJavaHome() {
@@ -118,5 +95,25 @@ public class DefaultJavaExtension implements JavaExtension {
         && Objects.equals(sourceCompatibility, other.sourceCompatibility)
         && Objects.equals(targetCompatibility, other.targetCompatibility)
         && Objects.equals(compilerArgs, other.compilerArgs);
+  }
+
+  @Override
+  public boolean isJavaExtension() {
+    return true;
+  }
+
+  @Override
+  public boolean isScalaExtension() {
+    return false;
+  }
+
+  @Override
+  public JavaExtension getAsJavaExtension() {
+    return this;
+  }
+
+  @Override
+  public ScalaExtension getAsScalaExtension() {
+    return null;
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultJavaLanguage.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultJavaLanguage.java
@@ -25,6 +25,15 @@ public class DefaultJavaLanguage implements SupportedLanguage<JavaExtension> {
 
   @Override
   public JavaExtension getExtension(Map<String, LanguageExtension> extensions) {
-    return (JavaExtension) extensions.get(getBspName());
+    LanguageExtension extension = extensions.get(getBspName());
+    if (extension == null) {
+      return null;
+    }
+    if (extension.isJavaExtension()) {
+      return extension.getAsJavaExtension();
+    }
+    throw new IllegalArgumentException(
+        "LanguageExtension: " + extension + " is not a JavaExtension."
+    );
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultScalaExtension.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultScalaExtension.java
@@ -3,10 +3,10 @@
 
 package com.microsoft.java.bs.gradle.model.impl;
 
+import com.microsoft.java.bs.gradle.model.JavaExtension;
 import com.microsoft.java.bs.gradle.model.ScalaExtension;
 
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,29 +25,6 @@ public class DefaultScalaExtension implements ScalaExtension {
   private String scalaBinaryVersion;
 
   private List<File> scalaJars;
-
-  @Override
-  public Object convert(ClassLoader classLoader) {
-    try {
-      Class<?> destinationClass = classLoader.loadClass(getClass().getName());
-      Object result = destinationClass.getConstructor().newInstance();
-      destinationClass.getDeclaredMethod("setScalaCompilerArgs", List.class)
-          .invoke(result, getScalaCompilerArgs());
-      destinationClass.getDeclaredMethod("setScalaOrganization", String.class)
-          .invoke(result, getScalaOrganization());
-      destinationClass.getDeclaredMethod("setScalaVersion", String.class)
-          .invoke(result, getScalaVersion());
-      destinationClass.getDeclaredMethod("setScalaBinaryVersion", String.class)
-          .invoke(result, getScalaBinaryVersion());
-      destinationClass.getDeclaredMethod("setScalaJars", List.class)
-          .invoke(result, getScalaJars());
-      return result;
-    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
-              | NoSuchMethodException | ClassNotFoundException | InstantiationException
-              | SecurityException e) {
-      throw new IllegalStateException("Error converting " + getClass().getName(), e);
-    }
-  }
 
   @Override
   public List<String> getScalaCompilerArgs() {
@@ -117,5 +94,25 @@ public class DefaultScalaExtension implements ScalaExtension {
             && Objects.equals(scalaVersion, other.scalaVersion)
             && Objects.equals(scalaBinaryVersion, other.scalaBinaryVersion)
             && Objects.equals(scalaJars, other.scalaJars);
+  }
+
+  @Override
+  public boolean isJavaExtension() {
+    return false;
+  }
+
+  @Override
+  public boolean isScalaExtension() {
+    return true;
+  }
+
+  @Override
+  public JavaExtension getAsJavaExtension() {
+    return null;
+  }
+
+  @Override
+  public ScalaExtension getAsScalaExtension() {
+    return this;
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultScalaLanguage.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultScalaLanguage.java
@@ -26,6 +26,15 @@ public class DefaultScalaLanguage implements SupportedLanguage<ScalaExtension> {
 
   @Override
   public ScalaExtension getExtension(Map<String, LanguageExtension> extensions) {
-    return (ScalaExtension) extensions.get(getBspName());
+    LanguageExtension extension = extensions.get(getBspName());
+    if (extension == null) {
+      return null;
+    }
+    if (extension.isScalaExtension()) {
+      return extension.getAsScalaExtension();
+    }
+    throw new IllegalArgumentException(
+        "LanguageExtension: " + extension + " is not a ScalaExtension."
+    );
   }
 }

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
@@ -138,6 +138,8 @@ class BuildTargetManagerTest {
     when(mocked.getModuleDependencies()).thenReturn(Collections.emptySet());
     when(mocked.getBuildTargetDependencies()).thenReturn(Collections.emptySet());
     JavaExtension mockedJavaExtension = mock(JavaExtension.class);
+    when(mockedJavaExtension.isJavaExtension()).thenReturn(true);
+    when(mockedJavaExtension.getAsJavaExtension()).thenReturn(mockedJavaExtension);
     when(mockedJavaExtension.getJavaVersion()).thenReturn("17");
     when(mockedJavaExtension.getSourceCompatibility()).thenReturn("17");
     when(mockedJavaExtension.getTargetCompatibility()).thenReturn("17");

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -295,6 +295,8 @@ class BuildTargetServiceTest {
     when(gradleBuildTarget.getSourceSet()).thenReturn(gradleSourceSet);
 
     JavaExtension mockedJavaExtension = mock(JavaExtension.class);
+    when(mockedJavaExtension.isJavaExtension()).thenReturn(true);
+    when(mockedJavaExtension.getAsJavaExtension()).thenReturn(mockedJavaExtension);
     List<String> compilerArgs = new ArrayList<>();
     compilerArgs.add("--add-opens");
     compilerArgs.add("java.base/java.lang=ALL-UNNAMED");
@@ -326,6 +328,8 @@ class BuildTargetServiceTest {
     compilerArgs.add("-encoding");
     compilerArgs.add("utf8");
     ScalaExtension mockedScalaExtension = mock(ScalaExtension.class);
+    when(mockedScalaExtension.isScalaExtension()).thenReturn(true);
+    when(mockedScalaExtension.getAsScalaExtension()).thenReturn(mockedScalaExtension);
     when(mockedScalaExtension.getScalaCompilerArgs()).thenReturn(compilerArgs);
     Map<String, LanguageExtension> extensions = new HashMap<>();
     extensions.put(SupportedLanguages.SCALA.getBspName(), mockedScalaExtension);


### PR DESCRIPTION
This PR removes the usage of a class loader for downcasting `LanguageExtesnion` to `JavaExtension` and `ScalaExtension`. Previously, the client JVM would attempt to determine the appropriate sub-interface type using a class loader.

### Changes:

- Introduced new methods in the `LanguageExtension` interface:
  - `isJavaExtension()` and `isScalaExtension()`: Checks if the current implementation is a specific sub-interface type.
  - `getAsJavaExtension()` and `getAsScalaExtension()`: Returns the instance as the specific sub-interface type if applicable.
- Moved the conversion logic from the client JVM to the Gradle daemon JVM, where the actual implementation of the `LanguageExtension` interface resides. This ensures correct type information is available for downcasting.
- Updated respective test cases to reflect the new approach.