### PR TITLE
Set env vars for Windows testing

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
@@ -197,7 +197,14 @@ public class GradleApiConnector {
             launcher.withArguments(args);
             launcher.setJvmArguments(jvmOptions);
             // env vars requires Gradle >= 3.5
-            launcher.setEnvironmentVariables(envVars);
+            if (envVars != null) {
+              // Running Gradle tests on Windows seems to require the `SystemRoot` env var
+              // Otherwise Windows complains "Unrecognized Windows Sockets error: 10106"
+              // Assumption is that current env vars plus specified env vars are all wanted.
+              Map<String, String> allEnvVars = new HashMap<>(System.getenv());
+              allEnvVars.putAll(envVars);
+              launcher.setEnvironmentVariables(allEnvVars);
+            }
             launcher.run();
           } catch (IOException e) {
             // caused by close the output stream, just simply log the error.

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -803,7 +803,6 @@ class BuildTargetServerIntegrationTest {
   }
 
   @Test
-  @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
   void testSingleMethodJunit() {
     withNewTestServer("java-tests", (gradleBuildServer, client) -> {
       // get targets
@@ -840,13 +839,6 @@ class BuildTargetServerIntegrationTest {
       List<String> emptyJvmOptions = new ArrayList<>();
       List<String> environmentVariables = new ArrayList<>();
       environmentVariables.add("EnvVar=Test");
-      // Running Gradle tests on Windows seems to require the SystemRoot env var
-      // Otherwise Windows complains "Unrecognized Windows Sockets error: 10106"
-      String systemRoot = System.getenv("SystemRoot");
-      if (systemRoot != null) {
-        environmentVariables.add("SystemRoot=" + systemRoot);
-      }
-      // or whatever is relevant to that operating system
       ScalaTestSuites singleScalaTestSuites = new ScalaTestSuites(singleScalaTestSuiteSelections,
           emptyJvmOptions, environmentVariables);
       singleMethodTestParams.setData(singleScalaTestSuites);
@@ -1674,7 +1666,6 @@ class BuildTargetServerIntegrationTest {
   }
 
   @Test
-  @DisabledIfEnvironmentVariable(named = "CI", matches = "true")
   void testSingleMethodTestNg() {
     withNewTestServer("testng", (gradleBuildServer, client) -> {
       // get targets
@@ -1712,13 +1703,6 @@ class BuildTargetServerIntegrationTest {
       List<String> emptyJvmOptions = new ArrayList<>();
       List<String> environmentVariables = new ArrayList<>();
       environmentVariables.add("EnvVar=Test");
-      // Running Gradle tests on Windows seems to require the SystemRoot env var
-      // Otherwise Windows complains "Unrecognized Windows Sockets error: 10106"
-      String systemRoot = System.getenv("SystemRoot");
-      if (systemRoot != null) {
-        environmentVariables.add("SystemRoot=" + systemRoot);
-      }
-      // or whatever is relevant to that operating system
       ScalaTestSuites singleScalaTestSuites = new ScalaTestSuites(singleScalaTestSuiteSelections,
           emptyJvmOptions, environmentVariables);
       singleMethodTestParams.setData(singleScalaTestSuites);


### PR DESCRIPTION
Set `SystemRoot` in env vars when running tests.  Required to run Gradle tests in Windows