### PR TITLE
fix - Cannot get test display name

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/TestReportReporter.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/reporter/TestReportReporter.java
@@ -88,7 +88,7 @@ public class TestReportReporter extends ProgressReporter {
       String displayName;
       try {
         displayName = desc.getTestDisplayName();
-      } catch (NoSuchMethodError e) {
+      } catch (NoSuchMethodError | AbstractMethodError e) {
         displayName = desc.getDisplayName();
       }
       TestName currentTestName = new TestName(displayName, desc.getSuiteName(),


### PR DESCRIPTION
AbstractMethodError will be thrown when the project gradle version < 8.8