### PR TITLE
[WIP] fix - leverage build tree path

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/BuildTargetDependency.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/BuildTargetDependency.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
  * In Java this is a project:sourceset dependency on a project:sourceset.
  */
 public interface BuildTargetDependency extends Serializable {
-  public String getProjectPath();
+  public String getBuildTreePath();
 
   public String getSourceSetName();
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/ExperimentalFeatures.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/ExperimentalFeatures.java
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model;
+
+/**
+ * Experimental features that can be enabled.
+ */
+public class ExperimentalFeatures {
+  public static final String ACCURATE_SOURCESET_DEPENDENCIES = "accurateSourceSetDependencies";
+}

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
@@ -30,9 +30,9 @@ public interface GradleSourceSet extends Serializable {
   public String getProjectName();
 
   /**
-   * Equivalent to {@code org.gradle.api.Project.getPath()}.
+   * Equivalent to {@code org.gradle.api.Project.getBuildTreePath()}.
    */
-  public String getProjectPath();
+  public String getBuildTreePath();
 
   /**
    * Equivalent to {@code org.gradle.api.Project.getProjectDir()}.

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultBuildTargetDependency.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultBuildTargetDependency.java
@@ -14,19 +14,18 @@ import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 public class DefaultBuildTargetDependency implements BuildTargetDependency {
   private static final long serialVersionUID = 1L;
 
-  private String projectPath;
+  private String buildTreePath;
 
   private String sourceSetName;
 
-  public DefaultBuildTargetDependency(String projectPath, String sourceSetName) {
-    this.projectPath = projectPath;
+  public DefaultBuildTargetDependency(String buildTreePath, String sourceSetName) {
+    this.buildTreePath = buildTreePath;
     this.sourceSetName = sourceSetName;
   }
 
   public DefaultBuildTargetDependency(GradleSourceSet sourceSet) {
-    this(sourceSet.getProjectPath(), sourceSet.getSourceSetName());
+    this(sourceSet.getBuildTreePath(), sourceSet.getSourceSetName());
   }
-
 
   /**
    * Copy constructor.
@@ -34,16 +33,16 @@ public class DefaultBuildTargetDependency implements BuildTargetDependency {
    * @param buildTargetDependency the other instance to copy from.
    */
   public DefaultBuildTargetDependency(BuildTargetDependency buildTargetDependency) {
-    this.projectPath = buildTargetDependency.getProjectPath();
+    this.buildTreePath = buildTargetDependency.getBuildTreePath();
     this.sourceSetName = buildTargetDependency.getSourceSetName();
   }
 
-  public String getProjectPath() {
-    return projectPath;
+  public String getBuildTreePath() {
+    return buildTreePath;
   }
 
-  public void setProjectPath(String projectPath) {
-    this.projectPath = projectPath;
+  public void setBuildTreePath(String buildTreePath) {
+    this.buildTreePath = buildTreePath;
   }
 
   public String getSourceSetName() {
@@ -56,7 +55,7 @@ public class DefaultBuildTargetDependency implements BuildTargetDependency {
 
   @Override
   public int hashCode() {
-    return Objects.hash(projectPath, sourceSetName);
+    return Objects.hash(buildTreePath, sourceSetName);
   }
 
   @Override
@@ -71,7 +70,7 @@ public class DefaultBuildTargetDependency implements BuildTargetDependency {
       return false;
     }
     DefaultBuildTargetDependency other = (DefaultBuildTargetDependency) obj;
-    return Objects.equals(projectPath, other.projectPath)
+    return Objects.equals(buildTreePath, other.buildTreePath)
         && Objects.equals(sourceSetName, other.sourceSetName);
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -27,7 +27,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   private String projectName;
 
-  private String projectPath;
+  private String buildTreePath;
 
   private File projectDir;
 
@@ -72,7 +72,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
     this.gradleVersion = gradleSourceSet.getGradleVersion();
     this.displayName = gradleSourceSet.getDisplayName();
     this.projectName = gradleSourceSet.getProjectName();
-    this.projectPath = gradleSourceSet.getProjectPath();
+    this.buildTreePath = gradleSourceSet.getBuildTreePath();
     this.projectDir = gradleSourceSet.getProjectDir();
     this.rootDir = gradleSourceSet.getRootDir();
     this.sourceSetName = gradleSourceSet.getSourceSetName();
@@ -135,12 +135,12 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
   }
 
   @Override
-  public String getProjectPath() {
-    return projectPath;
+  public String getBuildTreePath() {
+    return buildTreePath;
   }
 
-  public void setProjectPath(String projectPath) {
-    this.projectPath = projectPath;
+  public void setBuildTreePath(String buildTreePath) {
+    this.buildTreePath = buildTreePath;
   }
 
   @Override
@@ -286,7 +286,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   @Override
   public int hashCode() {
-    return Objects.hash(gradleVersion, displayName, projectName, projectPath,
+    return Objects.hash(gradleVersion, displayName, projectName, buildTreePath,
         projectDir, rootDir, sourceSetName, classesTaskName, cleanTaskName, taskNames, sourceDirs,
         generatedSourceDirs, sourceOutputDir, resourceDirs, resourceOutputDir,
         compileClasspath, moduleDependencies, buildTargetDependencies,
@@ -308,7 +308,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
     return Objects.equals(gradleVersion, other.gradleVersion)
         && Objects.equals(displayName, other.displayName)
         && Objects.equals(projectName, other.projectName)
-        && Objects.equals(projectPath, other.projectPath)
+        && Objects.equals(buildTreePath, other.buildTreePath)
         && Objects.equals(projectDir, other.projectDir)
         && Objects.equals(rootDir, other.rootDir)
         && Objects.equals(sourceSetName, other.sourceSetName)

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPlugin.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPlugin.java
@@ -3,8 +3,10 @@
 
 package com.microsoft.java.bs.gradle.plugin;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -20,6 +22,7 @@ import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 public class GradleBuildServerPlugin implements Plugin<Project> {
 
   public static final List<LanguageModelBuilder> SUPPORTED_LANGUAGE_BUILDERS = new LinkedList<>();
+  public static final Set<String> EXPERIMENTAL_FEATURES = new HashSet<>();
 
   private final ToolingModelBuilderRegistry registry;
 
@@ -29,6 +32,7 @@ public class GradleBuildServerPlugin implements Plugin<Project> {
   @Inject
   public GradleBuildServerPlugin(ToolingModelBuilderRegistry registry) {
     registerSupportedLanguages();
+    registerExperimentalFeatures();
     this.registry = registry;
   }
 
@@ -47,6 +51,16 @@ public class GradleBuildServerPlugin implements Plugin<Project> {
         } else if (language.equalsIgnoreCase(SupportedLanguages.SCALA.getBspName())) {
           SUPPORTED_LANGUAGE_BUILDERS.add(new ScalaLanguageModelBuilder());
         }
+      }
+    }
+  }
+
+  private void registerExperimentalFeatures() {
+    String experimentalFeatures = System.getProperty("bsp.gradle.experimentalFeatures");
+    if (experimentalFeatures != null) {
+      String[] features = experimentalFeatures.split(",");
+      for (String feature : features) {
+        EXPERIMENTAL_FEATURES.add(feature);
       }
     }
   }

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -13,8 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.microsoft.java.bs.gradle.model.ExperimentalFeatures;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSetsMetadata;
+
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.CopySpec;
@@ -66,11 +69,10 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
         DefaultGradleSourceSet gradleSourceSet = new DefaultGradleSourceSet();
         cache.addGradleSourceSet(sourceSet, gradleSourceSet);
         cache.addProject(sourceSet, project);
-        gradleSourceSet.setBuildTargetDependencies(new HashSet<>());
         gradleSourceSet.setGradleVersion(project.getGradle().getGradleVersion());
         gradleSourceSet.setProjectName(project.getName());
         String projectPath = project.getPath();
-        gradleSourceSet.setProjectPath(projectPath);
+        gradleSourceSet.setBuildTreePath(project.getBuildTreePath());
         gradleSourceSet.setProjectDir(project.getProjectDir());
         gradleSourceSet.setRootDir(project.getRootDir());
         gradleSourceSet.setSourceSetName(sourceSet.getName());
@@ -80,7 +82,7 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
         gradleSourceSet.setCleanTaskName(cleanTaskName);
         Set<String> taskNames = new HashSet<>();
         gradleSourceSet.setTaskNames(taskNames);
-        String projectName = stripPathPrefix(gradleSourceSet.getProjectPath());
+        String projectName = stripPathPrefix(gradleSourceSet.getBuildTreePath());
         if (projectName == null || projectName.length() == 0) {
           projectName = gradleSourceSet.getProjectName();
         }
@@ -109,9 +111,13 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
         exclusionFromDependencies.addAll(generatedSrcDirs);
 
         // classpath
-        List<File> compileClasspath = new LinkedList<>(sourceSet.getCompileClasspath().getFiles());
+        List<File> compileClasspath = new LinkedList<>();
+        try {
+          compileClasspath.addAll(sourceSet.getCompileClasspath().getFiles());
+        } catch (GradleException e) {
+          // ignore
+        }
         gradleSourceSet.setCompileClasspath(compileClasspath);
-
         sourceSetsToClasspath.put(gradleSourceSet, compileClasspath);
 
         // source output dir
@@ -162,31 +168,9 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
         }
       });
 
-      if (!sourceSets.isEmpty()) {
-        // get all archive tasks for this project and find the dirs that are included in the archive
-        TaskCollection<AbstractArchiveTask> archiveTasks =
-            project.getTasks().withType(AbstractArchiveTask.class);
-        for (AbstractArchiveTask archiveTask : archiveTasks) {
-          Set<Object> archiveSourcePaths = getArchiveSourcePaths(archiveTask.getRootSpec());
-          for (Object sourcePath : archiveSourcePaths) {
-            sourceSets.forEach(sourceSet -> {
-              DefaultGradleSourceSet gradleSourceSet = cache.getGradleSourceSet(sourceSet);
-              if (gradleSourceSet == null) {
-                return;
-              }
-
-              if (sourceSet.getOutput().equals(sourcePath)) {
-                File archiveFile;
-                if (GradleVersion.current().compareTo(GradleVersion.version("5.1")) >= 0) {
-                  archiveFile = archiveTask.getArchiveFile().get().getAsFile();
-                } else {
-                  archiveFile = archiveTask.getArchivePath();
-                }
-                outputsToSourceSet.put(archiveFile, gradleSourceSet);
-              }
-            });
-          }
-        }
+      if (GradleBuildServerPlugin. EXPERIMENTAL_FEATURES.contains(
+          ExperimentalFeatures.ACCURATE_SOURCESET_DEPENDENCIES) && !sourceSets.isEmpty()) {
+        gatherArchiveTasks(outputsToSourceSet, cache, project, sourceSets);
       }
     }
 
@@ -230,6 +214,7 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
           exclusionFromDependencies);
       collector.collectByConfigurationNames(getClasspathConfigurationNames(sourceSet));
       gradleSourceSet.setModuleDependencies(collector.getModuleDependencies());
+      gradleSourceSet.setBuildTargetDependencies(collector.getProjectDependencies());
     }
   }
 
@@ -315,6 +300,41 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
     }
 
     return null;
+  }
+
+  /**
+   * get all archive tasks for this project and maintain the archive file
+   * to source set mapping.
+   */
+  private void gatherArchiveTasks(Map<File, GradleSourceSet> outputsToSourceSet,
+      SourceSetCache cache, Project project, SourceSetContainer sourceSets) {
+    try {
+      TaskCollection<AbstractArchiveTask> archiveTasks =
+          project.getTasks().withType(AbstractArchiveTask.class);
+      for (AbstractArchiveTask archiveTask : archiveTasks) {
+        Set<Object> archiveSourcePaths = getArchiveSourcePaths(archiveTask.getRootSpec());
+        for (Object sourcePath : archiveSourcePaths) {
+          sourceSets.forEach(sourceSet -> {
+            DefaultGradleSourceSet gradleSourceSet = cache.getGradleSourceSet(sourceSet);
+            if (gradleSourceSet == null) {
+              return;
+            }
+
+            if (sourceSet.getOutput().equals(sourcePath)) {
+              File archiveFile;
+              if (GradleVersion.current().compareTo(GradleVersion.version("5.1")) >= 0) {
+                archiveFile = archiveTask.getArchiveFile().get().getAsFile();
+              } else {
+                archiveFile = archiveTask.getArchivePath();
+              }
+              outputsToSourceSet.put(archiveFile, gradleSourceSet);
+            }
+          });
+        }
+      }
+    } catch (Throwable e) {
+      // ignore
+    }
   }
 
   private Set<Object> getArchiveSourcePaths(CopySpec copySpec) {

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/dependency/DependencyCollector.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/dependency/DependencyCollector.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -16,6 +17,7 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ArtifactResolutionResult;
 import org.gradle.api.artifacts.result.ArtifactResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
@@ -30,8 +32,10 @@ import org.gradle.language.base.artifact.SourcesArtifact;
 import org.gradle.language.java.artifact.JavadocArtifact;
 
 import com.microsoft.java.bs.gradle.model.Artifact;
+import com.microsoft.java.bs.gradle.model.BuildTargetDependency;
 import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
 import com.microsoft.java.bs.gradle.model.impl.DefaultArtifact;
+import com.microsoft.java.bs.gradle.model.impl.DefaultBuildTargetDependency;
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleModuleDependency;
 import org.gradle.util.GradleVersion;
 
@@ -45,6 +49,7 @@ public class DependencyCollector {
   private final Project project;
   private final Set<File> exclusionFromDependencies;
   private final Set<GradleModuleDependency> moduleDependencies;
+  private Set<BuildTargetDependency> buildTargetDependencies;
 
   /**
    * Instantiates a new dependency collector.
@@ -53,10 +58,15 @@ public class DependencyCollector {
     this.project = project;
     this.exclusionFromDependencies = exclusionFromDependencies;
     this.moduleDependencies = new LinkedHashSet<>();
+    this.buildTargetDependencies = new LinkedHashSet<>();
   }
 
   public Set<GradleModuleDependency> getModuleDependencies() {
     return moduleDependencies;
+  }
+
+  public Set<BuildTargetDependency> getProjectDependencies() {
+    return buildTargetDependencies;
   }
 
   /**
@@ -102,6 +112,8 @@ public class DependencyCollector {
       resolveFileArtifactDependency((OpaqueComponentArtifactIdentifier) id, artifactFile);
     } else if (id instanceof ComponentFileArtifactIdentifier) {
       resolveFileArtifactDependency((ComponentFileArtifactIdentifier) id, artifactFile);
+    } else if (id.getComponentIdentifier() instanceof ProjectComponentIdentifier) {
+      resolveProjectDependency((ProjectComponentIdentifier) id.getComponentIdentifier());
     }
   }
 
@@ -195,12 +207,23 @@ public class DependencyCollector {
     if (resolvedArtifactFile != null) {
       artifacts.add(new DefaultArtifact(resolvedArtifactFile.toURI(), null));
     }
-  
+
     return new DefaultGradleModuleDependency(
         UNKNOWN,
         displayName,
         UNKNOWN,
         artifacts
     );
+  }
+
+  private void resolveProjectDependency(ProjectComponentIdentifier id) {
+    String buildTreePath = id.getBuildTreePath();
+    if (Objects.equals(buildTreePath, project.getBuildTreePath())) {
+      return;
+    }
+
+    buildTargetDependencies.add(new DefaultBuildTargetDependency(
+        buildTreePath, "main"
+    ));
   }
 }

--- a/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPluginTest.java
+++ b/plugin/src/test/java/com/microsoft/java/bs/gradle/plugin/GradleBuildServerPluginTest.java
@@ -173,7 +173,7 @@ class GradleBuildServerPluginTest {
     withSourceSets("junit5-jupiter-starter-gradle", gradleVersion, gradleSourceSets -> {
       assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
       for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {
-        assertEquals(":", gradleSourceSet.getProjectPath());
+        assertEquals(":", gradleSourceSet.getBuildTreePath());
         assertTrue(gradleSourceSet.getSourceSetName().equals("main")
             || gradleSourceSet.getSourceSetName().equals("test"));
         assertTrue(gradleSourceSet.getClassesTaskName().equals(":classes")
@@ -450,7 +450,7 @@ class GradleBuildServerPluginTest {
       assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
       for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {
         assertEquals("scala-2", gradleSourceSet.getProjectName());
-        assertEquals(":", gradleSourceSet.getProjectPath());
+        assertEquals(":", gradleSourceSet.getBuildTreePath());
         assertTrue(gradleSourceSet.getSourceSetName().equals("main")
                 || gradleSourceSet.getSourceSetName().equals("test"));
         assertTrue(gradleSourceSet.getClassesTaskName().equals(":classes")
@@ -518,7 +518,7 @@ class GradleBuildServerPluginTest {
       assertEquals(2, gradleSourceSets.getGradleSourceSets().size());
       for (GradleSourceSet gradleSourceSet : gradleSourceSets.getGradleSourceSets()) {
         assertEquals("scala-3", gradleSourceSet.getProjectName());
-        assertEquals(":", gradleSourceSet.getProjectPath());
+        assertEquals(":", gradleSourceSet.getBuildTreePath());
         assertTrue(gradleSourceSet.getSourceSetName().equals("main")
                 || gradleSourceSet.getSourceSetName().equals("test"));
         assertTrue(gradleSourceSet.getClassesTaskName().equals(":classes")

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
@@ -33,6 +33,7 @@ import com.microsoft.java.bs.core.internal.reporter.CompileProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.DefaultProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.ProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.TestReportReporter;
+import com.microsoft.java.bs.gradle.model.ExperimentalFeatures;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
 
 import ch.epfl.scala.bsp4j.BuildClient;
@@ -87,8 +88,10 @@ public class GradleApiConnector {
     ByteArrayOutputStream errorOut = new ByteArrayOutputStream();
     try (ProjectConnection connection = getGradleConnector(projectUri).connect();
          errorOut) {
+      boolean accurateResolution = preferenceManager.getPreferences().getExperimentalFeatures()
+          .contains(ExperimentalFeatures.ACCURATE_SOURCESET_DEPENDENCIES);
       BuildActionExecuter<GradleSourceSets> buildExecutor
-          = connection.action(new GetSourceSetsAction());
+          = connection.action(new GetSourceSetsAction(accurateResolution));
       buildExecutor.addProgressListener(reporter,
               OperationType.FILE_DOWNLOAD, OperationType.PROJECT_CONFIGURATION)
           .setStandardError(errorOut)
@@ -99,6 +102,8 @@ public class GradleApiConnector {
       }
       buildExecutor.addJvmArguments("-Dbsp.gradle.supportedLanguages="
           + String.join(",", preferenceManager.getClientSupportedLanguages()));
+      buildExecutor.addJvmArguments("-Dbsp.gradle.experimentalFeatures="
+          + String.join(",", preferenceManager.getPreferences().getExperimentalFeatures()));
       // since the model returned from Gradle TAPI is a wrapped object, here we re-construct it
       // via a copy constructor and return as a POJO.
       return new DefaultGradleSourceSets(buildExecutor.run());

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/actions/GetSourceSetsAction.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/actions/GetSourceSetsAction.java
@@ -26,6 +26,12 @@ import java.util.Set;
  */
 public class GetSourceSetsAction implements BuildAction<GradleSourceSets> {
 
+  private boolean accurateSourceSetDependencyResolution;
+
+  public GetSourceSetsAction(boolean accurateSourceSetDependencyResolution) {
+    this.accurateSourceSetDependencyResolution = accurateSourceSetDependencyResolution;
+  }
+
   /**
    * Executes the build action and retrieves source sets from the Gradle build.
    *
@@ -49,17 +55,17 @@ public class GetSourceSetsAction implements BuildAction<GradleSourceSets> {
     // Add dependencies
     var sourceSets = new ArrayList<GradleSourceSet>();
     for (var entry : sourceSetToClasspath.entrySet()) {
-
-      var dependencies = new HashSet<BuildTargetDependency>();
-      for (File file : entry.getValue()) {
-        GradleSourceSet otherSourceSet = outputsToSourceSet.get(file);
-        if (otherSourceSet != null && !Objects.equals(entry.getKey(), otherSourceSet)) {
-          dependencies.add(new DefaultBuildTargetDependency(otherSourceSet));
-        }
-      }
-
       DefaultGradleSourceSet sourceSet = new DefaultGradleSourceSet(entry.getKey());
-      sourceSet.setBuildTargetDependencies(dependencies);
+      if (accurateSourceSetDependencyResolution) {
+        var dependencies = new HashSet<BuildTargetDependency>();
+        for (File file : entry.getValue()) {
+          GradleSourceSet otherSourceSet = outputsToSourceSet.get(file);
+          if (otherSourceSet != null && !Objects.equals(entry.getKey(), otherSourceSet)) {
+            dependencies.add(new DefaultBuildTargetDependency(otherSourceSet));
+          }
+        }
+        sourceSet.setBuildTargetDependencies(dependencies);
+      }
       sourceSets.add(sourceSet);
 
     }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
@@ -82,10 +82,10 @@ public class BuildTargetManager {
         changedTargets.add(btId);
       }
       newCache.put(btId, buildTarget);
-      // Store the relationship between the project path and the build target id.
+      // Store the relationship between the build tree path and the build target id.
       // 'test' and other source sets are ignored.
       if ("main".equals(sourceSet.getSourceSetName())) {
-        projectPathToBuildTargetId.put(sourceSet.getProjectPath(), btId);
+        projectPathToBuildTargetId.put(sourceSet.getBuildTreePath(), btId);
       }
     }
     updateBuildTargetDependencies(newCache.values(), projectPathToBuildTargetId);
@@ -173,7 +173,7 @@ public class BuildTargetManager {
    */
   private void updateBuildTargetDependencies(
       Collection<GradleBuildTarget> gradleBuildTargets,
-      Map<String, BuildTargetIdentifier> projectPathToBuildTargetId
+      Map<String, BuildTargetIdentifier> buildTreePathToBuildTargetId
   ) {
     for (GradleBuildTarget gradleBuildTarget : gradleBuildTargets) {
       Set<BuildTargetDependency> buildTargetDependencies =
@@ -181,8 +181,8 @@ public class BuildTargetManager {
       if (buildTargetDependencies != null) {
         List<BuildTargetIdentifier> btDependencies = buildTargetDependencies.stream()
             .map(btDependency -> {
-              String path = btDependency.getProjectPath();
-              return projectPathToBuildTargetId.get(path);
+              String path = btDependency.getBuildTreePath();
+              return buildTreePathToBuildTargetId.get(path);
             })
             .filter(Objects::nonNull)
             .distinct()

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/model/Preferences.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/model/Preferences.java
@@ -58,6 +58,11 @@ public class Preferences {
   private Map<String, String> jdks;
 
   /**
+   * The experimental features that are enabled.
+   */
+  private List<String> experimentalFeatures;
+
+  /**
    * Initialize the preferences.
    */
   public Preferences() {
@@ -65,6 +70,7 @@ public class Preferences {
     gradleArguments = Collections.emptyList();
     gradleJvmArguments = Collections.emptyList();
     jdks = Collections.emptyMap();
+    experimentalFeatures = Collections.emptyList();
   }
 
   public String getGradleJavaHome() {
@@ -129,5 +135,13 @@ public class Preferences {
 
   public void setJdks(Map<String, String> jdks) {
     this.jdks = jdks;
+  }
+
+  public List<String> getExperimentalFeatures() {
+    return experimentalFeatures;
+  }
+
+  public void setExperimentalFeatures(List<String> experimentalFeatures) {
+    this.experimentalFeatures = experimentalFeatures;
   }
 }

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -81,7 +81,7 @@ class GradleApiConnectorTest {
       assertNotNull(SupportedLanguages.JAVA.getExtension(gradleSourceSet));
       assertNull(SupportedLanguages.SCALA.getExtension(gradleSourceSet));
       assertEquals("junit5-jupiter-starter-gradle", gradleSourceSet.getProjectName());
-      assertEquals(":", gradleSourceSet.getProjectPath());
+      assertEquals(":", gradleSourceSet.getBuildTreePath());
       assertEquals(projectDir, gradleSourceSet.getProjectDir());
       assertEquals(projectDir, gradleSourceSet.getRootDir());
     }
@@ -172,13 +172,13 @@ class GradleApiConnectorTest {
   private void assertHasBuildTargetDependency(GradleSourceSet sourceSet,
       GradleSourceSet dependency) {
     boolean exists = sourceSet.getBuildTargetDependencies().stream()
-        .anyMatch(dep -> dep.getProjectPath().equals(dependency.getProjectPath())
+        .anyMatch(dep -> dep.getBuildTreePath().equals(dependency.getBuildTreePath())
                       && dep.getSourceSetName().equals(dependency.getSourceSetName()));
     assertTrue(exists, () -> {
       String availableDependencies = sourceSet.getBuildTargetDependencies().stream()
-          .map(ss -> ss.getProjectPath() + ' ' + ss.getSourceSetName())
+          .map(ss -> ss.getBuildTreePath() + ' ' + ss.getSourceSetName())
           .collect(Collectors.joining(", "));
-      return "Dependency not found " + dependency.getProjectPath() + ' '
+      return "Dependency not found " + dependency.getBuildTreePath() + ' '
         + dependency.getSourceSetName() + ". Available: " + availableDependencies;
     });
   }

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
@@ -91,16 +91,16 @@ class BuildTargetManagerTest {
   @Test
   void testBuildTargetDependency() {
     GradleSourceSet gradleSourceSetFoo = getMockedTestGradleSourceSet();
-    when(gradleSourceSetFoo.getProjectPath()).thenReturn(":foo");
+    when(gradleSourceSetFoo.getBuildTreePath()).thenReturn(":foo");
     when(gradleSourceSetFoo.getProjectDir()).thenReturn(new File("foo"));
 
 
     BuildTargetDependency buildTargetDependency = mock(BuildTargetDependency.class);
-    when(buildTargetDependency.getProjectPath()).thenReturn(":foo");
+    when(buildTargetDependency.getBuildTreePath()).thenReturn(":foo");
     Set<BuildTargetDependency> dependencies = new HashSet<>();
     dependencies.add(buildTargetDependency);
     GradleSourceSet gradleSourceSetBar = getMockedTestGradleSourceSet();
-    when(gradleSourceSetBar.getProjectPath()).thenReturn(":bar");
+    when(gradleSourceSetBar.getBuildTreePath()).thenReturn(":bar");
     when(gradleSourceSetBar.getProjectDir()).thenReturn(new File("bar"));
     when(gradleSourceSetBar.getBuildTargetDependencies()).thenReturn(dependencies);
 


### PR DESCRIPTION
@Arthurm1 Would like to hear your input on this change proposal.

#### Background
Previously, the build server implementation does not handle the include build well, because we didn't know the 'trick' of build action. So the project dependencies were not recovered from the build tree root.

To fix some of the include build bugs, https://github.com/microsoft/build-server-for-gradle/pull/107 was introduced. But I found that #107 has its own problem:

- `sourceSet.getCompileClasspath().getFiles()` may return runtime exceptions, and thus cause the import failure.
- Some internal apis are used when we tried to establish the relationship between the output jars and the source sets.

Now, since we can use build action, it seems that the solution can be simpler.

Considering that, in the `BuildTargetManager`, only `main` sourceset is considered as the build target dependencies, looks like the old implementation is enough to handle the project dependencies.

I've two proposals on this:
1. Which is this PR, it marks the changes in #107 as an experimental feature, since #107 can give more accurate dependency relationship between source sets.
2. Revert the change in #107, and related types, like `GradleSourceSetsMetadata`, which may makes the code base more simpler.

WDYT?
