### PR TITLE
fix - Unsupported class file for the build action class

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,3 +1,11 @@
+plugins {
+    id 'java-library'
+}
+
 java {
   sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+dependencies {
+    api 'org.gradle:gradle-tooling-api:8.8'
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/actions/GetSourceSetsAction.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/actions/GetSourceSetsAction.java
@@ -1,4 +1,7 @@
-package com.microsoft.java.bs.core.internal.gradle.actions;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model.actions;
 
 import com.microsoft.java.bs.gradle.model.BuildTargetDependency;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
@@ -19,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Map.Entry;
 
 /**
  * {@link BuildAction} that retrieves {@link DefaultGradleSourceSet} from a Gradle build,
@@ -33,9 +37,9 @@ public class GetSourceSetsAction implements BuildAction<GradleSourceSets> {
    */
   @Override
   public GradleSourceSets execute(BuildController buildController) {
-    var traversedProjects = new HashSet<String>();
-    var sourceSetToClasspath = new HashMap<GradleSourceSet, List<File>>();
-    var outputsToSourceSet = new HashMap<File, GradleSourceSet>();
+    Set<String> traversedProjects = new HashSet<>();
+    Map<GradleSourceSet, List<File>> sourceSetToClasspath = new HashMap<>();
+    Map<File, GradleSourceSet> outputsToSourceSet = new HashMap<>();
 
     GradleBuild buildModel = buildController.getBuildModel();
     String rootProjectName = buildModel.getRootProject().getName();
@@ -47,10 +51,9 @@ public class GetSourceSetsAction implements BuildAction<GradleSourceSets> {
         rootProjectName);
 
     // Add dependencies
-    var sourceSets = new ArrayList<GradleSourceSet>();
-    for (var entry : sourceSetToClasspath.entrySet()) {
-
-      var dependencies = new HashSet<BuildTargetDependency>();
+    List<GradleSourceSet> sourceSets = new ArrayList<>();
+    for (Entry<GradleSourceSet, List<File>> entry : sourceSetToClasspath.entrySet()) {
+      Set<BuildTargetDependency> dependencies = new HashSet<>();
       for (File file : entry.getValue()) {
         GradleSourceSet otherSourceSet = outputsToSourceSet.get(file);
         if (otherSourceSet != null && !Objects.equals(entry.getKey(), otherSourceSet)) {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -20,6 +20,7 @@ java {
 }
 
 jar {
+  dependsOn ':model:jar'
   from {
     configurations.bundled.collect {
       it.isDirectory() ? it : zipTree(it)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     implementation project(':model')
-    implementation 'org.gradle:gradle-tooling-api:8.8'
     implementation 'ch.epfl.scala:bsp4j:2.1.0-M4'
     implementation 'org.apache.commons:commons-lang3:3.13.0'
 

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import com.microsoft.java.bs.core.internal.gradle.actions.GetSourceSetsAction;
+
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSets;
 import org.gradle.tooling.BuildActionExecuter;
 import org.gradle.tooling.BuildException;
@@ -34,6 +34,7 @@ import com.microsoft.java.bs.core.internal.reporter.DefaultProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.ProgressReporter;
 import com.microsoft.java.bs.core.internal.reporter.TestReportReporter;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
+import com.microsoft.java.bs.gradle.model.actions.GetSourceSetsAction;
 
 import ch.epfl.scala.bsp4j.BuildClient;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
@@ -87,8 +88,9 @@ public class GradleApiConnector {
     ByteArrayOutputStream errorOut = new ByteArrayOutputStream();
     try (ProjectConnection connection = getGradleConnector(projectUri).connect();
          errorOut) {
-      BuildActionExecuter<GradleSourceSets> buildExecutor
-          = connection.action(new GetSourceSetsAction());
+      BuildActionExecuter<GradleSourceSets> buildExecutor =
+          Utils.getBuildActionExecuter(connection, preferenceManager.getPreferences(),
+            new GetSourceSetsAction());
       buildExecutor.addProgressListener(reporter,
               OperationType.FILE_DOWNLOAD, OperationType.PROJECT_CONFIGURATION)
           .setStandardError(errorOut)

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
@@ -12,10 +12,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildActionExecuter;
 import org.gradle.tooling.BuildLauncher;
 import org.gradle.tooling.ConfigurableLauncher;
 import org.gradle.tooling.GradleConnector;
-import org.gradle.tooling.ModelBuilder;
 import org.gradle.tooling.ProjectConnection;
 import org.gradle.tooling.TestLauncher;
 import org.gradle.util.GradleVersion;
@@ -48,7 +49,7 @@ public class Utils {
    * Get the Gradle connector for the project.
    *
    * @param projectUri The project uri.
-   */ 
+   */
   public static GradleConnector getProjectConnector(URI projectUri,
       Preferences preferences) {
     return getProjectConnector(new File(projectUri), preferences);
@@ -84,15 +85,16 @@ public class Utils {
   }
 
   /**
-   * Get the model builder for the given project connection.
+   * Get the build action executer for the given project connection.
    *
-   * @param <T> The type of the model.
+   * @param <T> the result type
    * @param connection The project connection.
-   * @param clazz The class of the model.
+   * @param preferences The preferences.
+   * @param action The build action.
    */
-  public static <T> ModelBuilder<T> getModelBuilder(ProjectConnection connection,
-      Preferences preferences, Class<T> clazz) {
-    return setLauncherProperties(connection.model(clazz), preferences);
+  public static <T> BuildActionExecuter<T> getBuildActionExecuter(ProjectConnection connection,
+      Preferences preferences, BuildAction<T> action) {
+    return setLauncherProperties(connection.action(action), preferences);
   }
 
   /**
@@ -194,7 +196,7 @@ public class Utils {
     if (StringUtils.isNotBlank(gradleUserHome)) {
       return new File(gradleUserHome);
     }
-    
+
     return getFileFromEnvOrProperty(GRADLE_USER_HOME);
   }
 


### PR DESCRIPTION
- Move the GetSourceSetsAction class to the model module, to ensure that the GetSourceSetsAction class is compiled on level 1.8.
- Set the required properties to the BuildActionExecuter.

fix #169 