### PR TITLE
fix - Use project dir instead of project path

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/BuildTargetDependency.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/BuildTargetDependency.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
  * In Java this is a project:sourceset dependency on a project:sourceset.
  */
 public interface BuildTargetDependency extends Serializable {
-  public String getProjectPath();
+  public String getProjectDir();
 
   public String getSourceSetName();
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultBuildTargetDependency.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultBuildTargetDependency.java
@@ -14,19 +14,18 @@ import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 public class DefaultBuildTargetDependency implements BuildTargetDependency {
   private static final long serialVersionUID = 1L;
 
-  private String projectPath;
+  private String projectDir;
 
   private String sourceSetName;
 
-  public DefaultBuildTargetDependency(String projectPath, String sourceSetName) {
-    this.projectPath = projectPath;
+  public DefaultBuildTargetDependency(String projectDir, String sourceSetName) {
+    this.projectDir = projectDir;
     this.sourceSetName = sourceSetName;
   }
 
   public DefaultBuildTargetDependency(GradleSourceSet sourceSet) {
-    this(sourceSet.getProjectPath(), sourceSet.getSourceSetName());
+    this(sourceSet.getProjectDir().getAbsolutePath(), sourceSet.getSourceSetName());
   }
-
 
   /**
    * Copy constructor.
@@ -34,18 +33,20 @@ public class DefaultBuildTargetDependency implements BuildTargetDependency {
    * @param buildTargetDependency the other instance to copy from.
    */
   public DefaultBuildTargetDependency(BuildTargetDependency buildTargetDependency) {
-    this.projectPath = buildTargetDependency.getProjectPath();
+    this.projectDir = buildTargetDependency.getProjectDir();
     this.sourceSetName = buildTargetDependency.getSourceSetName();
   }
 
-  public String getProjectPath() {
-    return projectPath;
+  @Override
+  public String getProjectDir() {
+    return projectDir;
   }
 
-  public void setProjectPath(String projectPath) {
-    this.projectPath = projectPath;
+  public void setProjectDir(String projectDir) {
+    this.projectDir = projectDir;
   }
 
+  @Override
   public String getSourceSetName() {
     return sourceSetName;
   }
@@ -56,7 +57,7 @@ public class DefaultBuildTargetDependency implements BuildTargetDependency {
 
   @Override
   public int hashCode() {
-    return Objects.hash(projectPath, sourceSetName);
+    return Objects.hash(projectDir, sourceSetName);
   }
 
   @Override
@@ -71,7 +72,7 @@ public class DefaultBuildTargetDependency implements BuildTargetDependency {
       return false;
     }
     DefaultBuildTargetDependency other = (DefaultBuildTargetDependency) obj;
-    return Objects.equals(projectPath, other.projectPath)
+    return Objects.equals(projectDir, other.projectDir)
         && Objects.equals(sourceSetName, other.sourceSetName);
   }
 }

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -80,7 +80,7 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
         gradleSourceSet.setCleanTaskName(cleanTaskName);
         Set<String> taskNames = new HashSet<>();
         gradleSourceSet.setTaskNames(taskNames);
-        String projectName = stripPathPrefix(gradleSourceSet.getProjectPath());
+        String projectName = stripPathPrefix(projectPath);
         if (projectName == null || projectName.length() == 0) {
           projectName = gradleSourceSet.getProjectName();
         }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManager.java
@@ -82,10 +82,10 @@ public class BuildTargetManager {
         changedTargets.add(btId);
       }
       newCache.put(btId, buildTarget);
-      // Store the relationship between the project path and the build target id.
+      // Store the relationship between the project dir and the build target id.
       // 'test' and other source sets are ignored.
       if ("main".equals(sourceSet.getSourceSetName())) {
-        projectPathToBuildTargetId.put(sourceSet.getProjectPath(), btId);
+        projectPathToBuildTargetId.put(sourceSet.getProjectDir().getAbsolutePath(), btId);
       }
     }
     updateBuildTargetDependencies(newCache.values(), projectPathToBuildTargetId);
@@ -181,7 +181,7 @@ public class BuildTargetManager {
       if (buildTargetDependencies != null) {
         List<BuildTargetIdentifier> btDependencies = buildTargetDependencies.stream()
             .map(btDependency -> {
-              String path = btDependency.getProjectPath();
+              String path = btDependency.getProjectDir();
               return projectPathToBuildTargetId.get(path);
             })
             .filter(Objects::nonNull)

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -172,11 +172,11 @@ class GradleApiConnectorTest {
   private void assertHasBuildTargetDependency(GradleSourceSet sourceSet,
       GradleSourceSet dependency) {
     boolean exists = sourceSet.getBuildTargetDependencies().stream()
-        .anyMatch(dep -> dep.getProjectPath().equals(dependency.getProjectPath())
+        .anyMatch(dep -> dep.getProjectDir().equals(dependency.getProjectDir().getAbsolutePath())
                       && dep.getSourceSetName().equals(dependency.getSourceSetName()));
     assertTrue(exists, () -> {
       String availableDependencies = sourceSet.getBuildTargetDependencies().stream()
-          .map(ss -> ss.getProjectPath() + ' ' + ss.getSourceSetName())
+          .map(ss -> ss.getProjectDir() + ' ' + ss.getSourceSetName())
           .collect(Collectors.joining(", "));
       return "Dependency not found " + dependency.getProjectPath() + ' '
         + dependency.getSourceSetName() + ". Available: " + availableDependencies;

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/managers/BuildTargetManagerTest.java
@@ -96,7 +96,7 @@ class BuildTargetManagerTest {
 
 
     BuildTargetDependency buildTargetDependency = mock(BuildTargetDependency.class);
-    when(buildTargetDependency.getProjectPath()).thenReturn(":foo");
+    when(buildTargetDependency.getProjectDir()).thenReturn(new File("foo").getAbsolutePath());
     Set<BuildTargetDependency> dependencies = new HashSet<>();
     dependencies.add(buildTargetDependency);
     GradleSourceSet gradleSourceSetBar = getMockedTestGradleSourceSet();


### PR DESCRIPTION
- In composite build scenario, the project path is not based on the build tree root. Besides, the .getBuildTreePath() is not available before Gradle 8.3, we use the project dir to identify a Gradle project instead. The project dir is used in dependency resolution.

Fix the point 2 in https://github.com/microsoft/build-server-for-gradle/pull/154#issuecomment-2219647109