### PR TITLE
fix - --no-daemon not working on Gradle 8.9

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
@@ -67,7 +67,6 @@ public class GradleApiConnector {
   private String getGradleVersion(ProjectConnection connection) {
     BuildEnvironment model = connection
         .model(BuildEnvironment.class)
-        .withArguments("--no-daemon")
         .get();
     return model.getGradle().getGradleVersion();
   }


### PR DESCRIPTION
`--no-daemon` is not supported by gradle 8.9. You will get 

```
UnsupportedBuildArgumentException@13 "org.gradle.tooling.exceptions.UnsupportedBuildArgumentException: Could not fetch model of type 'BuildEnvironment' using connection to Gradle distribution 'https://services.gradle.org/distributions/gradle-8.9-bin.zip'.
Problem with provided build arguments: [--no-daemon]. 
Unknown command-line option '--no-daemon'.
Either it is not a valid build option or it is not supported in the target Gradle version.
Not all of the Gradle command line options are supported build arguments.
Examples of supported build arguments: '--info', '-p'.
Examples of unsupported build options: '--daemon', '-?', '-v'.
Please find more information in the javadoc for the BuildLauncher class."
```

On the other hand, getting `BuildEnvironment` won't invoke a new gradle daemon actually, looks like the tooling api directly handles it


fix https://github.com/microsoft/vscode-gradle/issues/1519