### PR TITLE
Test gradle.properties jvm args are used

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
@@ -56,8 +56,8 @@ public class GradleApiConnector {
    * Get the Gradle version of the project.
    */
   public String getGradleVersion(URI projectUri) {
-    try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
-      return getGradleVersion(connection);
+    try {
+      return getBuildEnvironment(projectUri).getGradle().getGradleVersion();
     } catch (BuildException e) {
       LOGGER.severe("Failed to get Gradle version: " + e.getMessage());
       return "";
@@ -65,10 +65,25 @@ public class GradleApiConnector {
   }
 
   private String getGradleVersion(ProjectConnection connection) {
-    BuildEnvironment model = connection
+    return getBuildEnvironment(connection).getGradle().getGradleVersion();
+  }
+
+  /**
+   * Get the Gradle {@link BuildEnvironment}.
+   *
+   * @param projectUri uri of the project
+   * @return an instance of {@link BuildEnvironment}
+   */
+  public BuildEnvironment getBuildEnvironment(URI projectUri) {
+    try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
+      return getBuildEnvironment(connection);
+    }
+  }
+
+  private BuildEnvironment getBuildEnvironment(ProjectConnection connection) {
+    return connection
         .model(BuildEnvironment.class)
         .get();
-    return model.getGradle().getGradleVersion();
   }
 
   /**

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -30,6 +31,7 @@ import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
 import ch.epfl.scala.bsp4j.StatusCode;
 
+import org.gradle.tooling.model.build.BuildEnvironment;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -50,8 +52,12 @@ class GradleApiConnectorTest {
   }
 
   private <A> A withConnector(Function<GradleApiConnector, A> function) {
+    return withConnector(function, new Preferences());
+  }
+
+  private <A> A withConnector(Function<GradleApiConnector, A> function, Preferences preferences) {
     PreferenceManager preferenceManager = new PreferenceManager();
-    preferenceManager.setPreferences(new Preferences());
+    preferenceManager.setPreferences(preferences);
     preferenceManager.setClientSupportedLanguages(SupportedLanguages.allBspNames);
     GradleApiConnector connector = new GradleApiConnector(preferenceManager);
     try {
@@ -328,5 +334,25 @@ class GradleApiConnectorTest {
       assertEquals(StatusCode.ERROR, failingTest);
       return null;
     });
+  }
+
+  @Test
+  void testGradleProperties() {
+    File projectDir = projectPath.resolve("gradle-properties").toFile();
+    withConnector(connector -> {
+      BuildEnvironment buildEnv = connector.getBuildEnvironment(projectDir.toURI());
+      assertTrue(buildEnv.getJava().getJvmArguments().stream()
+          .anyMatch(arg -> arg.contains("-Xmx1234m")));
+      return null;
+    });
+    // check supplying args doesn't wipe the gradle.properties ones
+    Preferences preferences = new Preferences();
+    preferences.setGradleJvmArguments(new ArrayList<>());
+    withConnector(connector -> {
+      BuildEnvironment buildEnv = connector.getBuildEnvironment(projectDir.toURI());
+      assertTrue(buildEnv.getJava().getJvmArguments().stream()
+          .anyMatch(arg -> arg.contains("-Xmx1234m")));
+      return null;
+    }, preferences);
   }
 }

--- a/testProjects/gradle-properties/build.gradle
+++ b/testProjects/gradle-properties/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+	id 'java'
+}

--- a/testProjects/gradle-properties/gradle.properties
+++ b/testProjects/gradle-properties/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx1234m

--- a/testProjects/gradle-properties/settings.gradle
+++ b/testProjects/gradle-properties/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gradle-properties'


### PR DESCRIPTION
Adds a test case to check that jvmargs in `gradle.properties` are respected.

It's possible to set jvm args at various points of the tooling api.  This checks they're being set in the `ProjectConnection`.  If the tooling API spins off another process to retrieve the model and that doesn't use the same jvm args, then that wouldn't be tested for here.

Uses [BuildEnvironment](https://docs.gradle.org/current/javadoc/org/gradle/tooling/model/build/BuildEnvironment.html) to check jvm args.