### PR TITLE
Handle BSP client cancellation

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/Launcher.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/Launcher.java
@@ -5,12 +5,14 @@ package com.microsoft.java.bs.core;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
 
 import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
 import com.microsoft.java.bs.core.internal.log.LogHandler;
@@ -69,9 +71,24 @@ public class Launcher {
   private static org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> createLauncherUsingStdIo() {
     return createLauncher(System.out, System.in);
   }
-
-  private static org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> 
+  
+  public static org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> 
       createLauncher(OutputStream outputStream, InputStream inputStream) {
+    return createLauncher(outputStream, inputStream, Executors.newCachedThreadPool(), null);
+  }
+
+  /**
+   * create a BSP Server Launcher.
+   *
+   * @param outputStream output stream to send outgoing messages
+   * @param inputStream input stream to listen for incoming messages
+   * @param threadPool the executor service used to start threads
+   * @param tracer message tracer for all BSP messages.  Set to null for no message tracing.
+   * @return new launcher
+   */
+  public static org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> createLauncher(
+      OutputStream outputStream, InputStream inputStream, ExecutorService threadPool,
+      PrintWriter tracer) {
     BuildTargetManager buildTargetManager = new BuildTargetManager();
     PreferenceManager preferenceManager = new PreferenceManager();
     GradleApiConnector connector = new GradleApiConnector(preferenceManager);
@@ -84,9 +101,10 @@ public class Launcher {
         org.eclipse.lsp4j.jsonrpc.Launcher.Builder<BuildClient>()
         .setOutput(outputStream)
         .setInput(inputStream)
+        .traceMessages(tracer)
         .setLocalService(gradleBuildServer)
         .setRemoteInterface(BuildClient.class)
-        .setExecutorService(Executors.newCachedThreadPool())
+        .setExecutorService(threadPool)
         .create();
     buildTargetService.setClient(launcher.getRemoteProxy());
     return launcher;

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnector.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
@@ -20,6 +21,7 @@ import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSets;
 import org.gradle.tooling.BuildActionExecuter;
 import org.gradle.tooling.BuildException;
 import org.gradle.tooling.BuildLauncher;
+import org.gradle.tooling.CancellationToken;
 import org.gradle.tooling.GradleConnectionException;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
@@ -44,31 +46,33 @@ import ch.epfl.scala.bsp4j.StatusCode;
  * Connect to Gradle Daemon via Gradle Tooling API.
  */
 public class GradleApiConnector {
-  private final Map<File, GradleConnector> connectors;
+  // cancellations especially can lead to concurrent calls to `connectors#computeIfAbsent`
+  private final ConcurrentHashMap<File, GradleConnector> connectors;
   private final PreferenceManager preferenceManager;
 
   public GradleApiConnector(PreferenceManager preferenceManager) {
     this.preferenceManager = preferenceManager;
-    connectors = new HashMap<>();
+    connectors = new ConcurrentHashMap<>();
   }
 
   /**
    * Get the Gradle version of the project.
    */
-  public String getGradleVersion(URI projectUri) {
+  public String getGradleVersion(URI projectUri, CancellationToken cancellationToken) {
     try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
-      return getGradleVersion(connection);
+      return getGradleVersion(connection, cancellationToken);
     } catch (BuildException e) {
       LOGGER.severe("Failed to get Gradle version: " + e.getMessage());
       return "";
     }
   }
 
-  private String getGradleVersion(ProjectConnection connection) {
-    BuildEnvironment model = connection
-        .model(BuildEnvironment.class)
-        .get();
-    return model.getGradle().getGradleVersion();
+  private String getGradleVersion(ProjectConnection connection,
+      CancellationToken cancellationToken) {
+    return Utils
+       .getModelBuilder(connection, preferenceManager.getPreferences(), BuildEnvironment.class,
+          cancellationToken)
+       .get().getGradle().getGradleVersion();
   }
 
   /**
@@ -78,7 +82,8 @@ public class GradleApiConnector {
    * @param client     connection to BSP client
    * @return an instance of {@link GradleSourceSets}
    */
-  public GradleSourceSets getGradleSourceSets(URI projectUri, BuildClient client) {
+  public GradleSourceSets getGradleSourceSets(URI projectUri, BuildClient client,
+      CancellationToken cancellationToken) {
     File initScript = Utils.getInitScriptFile();
     if (!initScript.exists()) {
       throw new IllegalStateException("Failed to get init script file.");
@@ -89,8 +94,8 @@ public class GradleApiConnector {
          errorOut) {
       BuildActionExecuter<GradleSourceSets> buildExecutor =
           Utils.getBuildActionExecuter(connection, preferenceManager.getPreferences(),
-            new GetSourceSetsAction());
-      buildExecutor.addProgressListener(reporter,
+            new GetSourceSetsAction(), cancellationToken)
+          .addProgressListener(reporter,
               OperationType.FILE_DOWNLOAD, OperationType.PROJECT_CONFIGURATION)
           .setStandardError(errorOut)
           .addArguments("--init-script", initScript.getAbsolutePath());
@@ -120,7 +125,8 @@ public class GradleApiConnector {
    * @param reporter   reporter on feedback from Gradle
    * @param tasks      tasks to run
    */
-  public StatusCode runTasks(URI projectUri, ProgressReporter reporter, String... tasks) {
+  public StatusCode runTasks(URI projectUri, ProgressReporter reporter,
+      String[] tasks, CancellationToken cancellationToken) {
     // Don't issue a start progress update - the listener will pick that up automatically
     final ByteArrayOutputStream errorOut = new ByteArrayOutputStream();
     StatusCode statusCode = StatusCode.OK;
@@ -128,7 +134,7 @@ public class GradleApiConnector {
          errorOut
     ) {
       BuildLauncher launcher = Utils.getBuildLauncher(connection,
-          preferenceManager.getPreferences());
+          preferenceManager.getPreferences(), cancellationToken);
       // TODO: consider to use outputstream to capture the output.
       launcher.addProgressListener(reporter, OperationType.TASK)
           .setStandardError(errorOut)
@@ -158,12 +164,13 @@ public class GradleApiConnector {
       List<String> args,
       Map<String, String> envVars,
       BuildClient client, String originId,
-      CompileProgressReporter compileProgressReporter) {
+      CompileProgressReporter compileProgressReporter,
+      CancellationToken cancellationToken) {
 
     StatusCode statusCode = StatusCode.OK;
     ProgressReporter reporter = new DefaultProgressReporter(client);
     try (ProjectConnection connection = getGradleConnector(projectUri).connect()) {
-      String gradleVersion = getGradleVersion(connection);
+      String gradleVersion = getGradleVersion(connection, cancellationToken);
       if (GradleVersion.version(gradleVersion).compareTo(GradleVersion.version("2.6")) < 0) {
         reporter.sendError("Error running test classes: Gradle version "
             + gradleVersion + " must be >= 2.6");
@@ -179,7 +186,7 @@ public class GradleApiConnector {
           final ByteArrayOutputStream errorOut = new ByteArrayOutputStream();
           try (errorOut) {
             TestLauncher launcher = Utils
-                .getTestLauncher(connection, preferenceManager.getPreferences())
+                .getTestLauncher(connection, preferenceManager.getPreferences(), cancellationToken)
                 .setStandardError(errorOut)
                 .addProgressListener(testReportReporter, OperationType.TEST);
             if (compileProgressReporter != null) {

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
@@ -15,8 +15,10 @@ import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildActionExecuter;
 import org.gradle.tooling.BuildLauncher;
+import org.gradle.tooling.CancellationToken;
 import org.gradle.tooling.ConfigurableLauncher;
 import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ModelBuilder;
 import org.gradle.tooling.ProjectConnection;
 import org.gradle.tooling.TestLauncher;
 import org.gradle.util.GradleVersion;
@@ -91,10 +93,25 @@ public class Utils {
    * @param connection The project connection.
    * @param preferences The preferences.
    * @param action The build action.
+   * @param cancellationToken Gradle cancellation token.
    */
   public static <T> BuildActionExecuter<T> getBuildActionExecuter(ProjectConnection connection,
-      Preferences preferences, BuildAction<T> action) {
-    return setLauncherProperties(connection.action(action), preferences);
+      Preferences preferences, BuildAction<T> action, CancellationToken cancellationToken) {
+    return setLauncherProperties(connection.action(action), preferences, cancellationToken);
+  }
+
+  /**
+   * Get the model builder for the given project connection.
+   *
+   * @param <T> the result type
+   * @param connection The project connection.
+   * @param preferences The preferences.
+   * @param clazz The model class.
+   * @param cancellationToken Gradle cancellation token.
+   */
+  public static <T> ModelBuilder<T> getModelBuilder(ProjectConnection connection,
+      Preferences preferences, Class<T> clazz, CancellationToken cancellationToken) {
+    return setLauncherProperties(connection.model(clazz), preferences, cancellationToken);
   }
 
   /**
@@ -102,10 +119,11 @@ public class Utils {
    *
    * @param connection The project connection.
    * @param preferences The preferences.
+   * @param cancellationToken Gradle cancellation token.
    */
   public static BuildLauncher getBuildLauncher(ProjectConnection connection,
-      Preferences preferences) {
-    return setLauncherProperties(connection.newBuild(), preferences);
+      Preferences preferences, CancellationToken cancellationToken) {
+    return setLauncherProperties(connection.newBuild(), preferences, cancellationToken);
   }
 
   /**
@@ -113,10 +131,11 @@ public class Utils {
    *
    * @param connection The project connection.
    * @param preferences The preferences.
+   * @param cancellationToken Gradle cancellation token.
    */
   public static TestLauncher getTestLauncher(ProjectConnection connection,
-      Preferences preferences) {
-    return setLauncherProperties(connection.newTestLauncher(), preferences);
+      Preferences preferences, CancellationToken cancellationToken) {
+    return setLauncherProperties(connection.newTestLauncher(), preferences, cancellationToken);
   }
 
   /**
@@ -124,9 +143,10 @@ public class Utils {
    *
    * @param launcher The launcher.
    * @param preferences The preferences.
+   * @param cancellationToken Gradle cancellation token.
    */
   public static <T extends ConfigurableLauncher<T>> T setLauncherProperties(T launcher,
-      Preferences preferences) {
+      Preferences preferences, CancellationToken cancellationToken) {
 
     File gradleJavaHomeFile = getGradleJavaHomeFile(preferences.getGradleJavaHome());
     if (gradleJavaHomeFile != null && gradleJavaHomeFile.exists()) {
@@ -141,6 +161,10 @@ public class Utils {
     List<String> gradleArguments = preferences.getGradleArguments();
     if (gradleArguments != null && !gradleArguments.isEmpty()) {
       launcher.withArguments(gradleArguments);
+    }
+
+    if (cancellationToken != null) {
+      launcher.withCancellationToken(cancellationToken);
     }
     return launcher;
   }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
@@ -7,21 +7,22 @@ import static com.microsoft.java.bs.core.Launcher.LOGGER;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.Level;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.eclipse.lsp4j.jsonrpc.CancelChecker;
-import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.gradle.tooling.CancellationToken;
+import org.gradle.tooling.CancellationTokenSource;
+import org.gradle.tooling.GradleConnector;
 
 import com.microsoft.java.bs.core.internal.log.BspTraceEntity;
 import com.microsoft.java.bs.core.internal.services.BuildTargetService;
 import com.microsoft.java.bs.core.internal.services.LifecycleService;
+import com.microsoft.java.bs.core.internal.utils.concurrent.CancellableFuture;
 
 import ch.epfl.scala.bsp4j.BuildServer;
 import ch.epfl.scala.bsp4j.CleanCacheParams;
@@ -77,7 +78,8 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
 
   @Override
   public CompletableFuture<InitializeBuildResult> buildInitialize(InitializeBuildParams params) {
-    return handleRequest("build/initialize", cc -> lifecycleService.initializeServer(params));
+    return handleRequest("build/initialize", cancelToken ->
+        lifecycleService.initializeServer(params, cancelToken));
   }
 
   @Override
@@ -87,7 +89,7 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
 
   @Override
   public CompletableFuture<Object> buildShutdown() {
-    return handleRequest("build/shutdown", cc ->
+    return handleRequest("build/shutdown", cancelToken ->
         lifecycleService.shutdown());
   }
 
@@ -98,22 +100,22 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
 
   @Override
   public CompletableFuture<WorkspaceBuildTargetsResult> workspaceBuildTargets() {
-    return handleRequest("workspace/buildTargets", cc ->
-        buildTargetService.getWorkspaceBuildTargets());
+    return handleRequest("workspace/buildTargets", cancelToken ->
+        buildTargetService.getWorkspaceBuildTargets(cancelToken));
   }
 
   @Override
   public CompletableFuture<Object> workspaceReload() {
-    return handleRequest("workspace/reload", cc -> {
-      buildTargetService.reloadWorkspace();
+    return handleRequest("workspace/reload", cancelToken -> {
+      buildTargetService.reloadWorkspace(cancelToken);
       return null;
     });
   }
 
   @Override
   public CompletableFuture<SourcesResult> buildTargetSources(SourcesParams params) {
-    return handleRequest("buildTarget/sources", cc ->
-        buildTargetService.getBuildTargetSources(params));
+    return handleRequest("buildTarget/sources", cancelToken ->
+        buildTargetService.getBuildTargetSources(params, cancelToken));
   }
 
   @Override
@@ -126,30 +128,32 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
   @Override
   public CompletableFuture<DependencySourcesResult> buildTargetDependencySources(
       DependencySourcesParams params) {
-    return handleRequest("buildTarget/dependencySources", cc ->
-            buildTargetService.getBuildTargetDependencySources(params));
+    return handleRequest("buildTarget/dependencySources", cancelToken ->
+        buildTargetService.getBuildTargetDependencySources(params, cancelToken));
   }
 
   @Override
   public CompletableFuture<ResourcesResult> buildTargetResources(ResourcesParams params) {
-    return handleRequest("buildTarget/resources", cc ->
-        buildTargetService.getBuildTargetResources(params));
+    return handleRequest("buildTarget/resources", cancelToken ->
+        buildTargetService.getBuildTargetResources(params, cancelToken));
   }
 
   @Override
   public CompletableFuture<OutputPathsResult> buildTargetOutputPaths(OutputPathsParams params) {
-    return handleRequest("buildTarget/outputPaths", cc ->
-        buildTargetService.getBuildTargetOutputPaths(params));
+    return handleRequest("buildTarget/outputPaths", cancelToken ->
+        buildTargetService.getBuildTargetOutputPaths(params, cancelToken));
   }
 
   @Override
   public CompletableFuture<CompileResult> buildTargetCompile(CompileParams params) {
-    return handleRequest("buildTarget/compile", cc -> buildTargetService.compile(params));
+    return handleRequest("buildTarget/compile", cancelToken ->
+       buildTargetService.compile(params, cancelToken));
   }
 
   @Override
   public CompletableFuture<TestResult> buildTargetTest(TestParams params) {
-    return handleRequest("buildTarget/test", cc -> buildTargetService.buildTargetTest(params));
+    return handleRequest("buildTarget/test", cancelToken ->
+       buildTargetService.buildTargetTest(params, cancelToken));
   }
 
   @Override
@@ -166,27 +170,28 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
 
   @Override
   public CompletableFuture<CleanCacheResult> buildTargetCleanCache(CleanCacheParams params) {
-    return handleRequest("buildTarget/cleanCache", cc -> buildTargetService.cleanCache(params));
+    return handleRequest("buildTarget/cleanCache", cancelToken ->
+        buildTargetService.cleanCache(params, cancelToken));
   }
 
   @Override
   public CompletableFuture<DependencyModulesResult> buildTargetDependencyModules(
       DependencyModulesParams params) {
-    return handleRequest("buildTarget/dependencyModules", cc ->
-        buildTargetService.getBuildTargetDependencyModules(params));
+    return handleRequest("buildTarget/dependencyModules", cancelToken ->
+        buildTargetService.getBuildTargetDependencyModules(params, cancelToken));
   }
 
   @Override
   public CompletableFuture<JavacOptionsResult> buildTargetJavacOptions(JavacOptionsParams params) {
-    return handleRequest("buildTarget/javacOptions", cc ->
-        buildTargetService.getBuildTargetJavacOptions(params));
+    return handleRequest("buildTarget/javacOptions", cancelToken ->
+        buildTargetService.getBuildTargetJavacOptions(params, cancelToken));
   }
 
   @Override
   public CompletableFuture<ScalacOptionsResult> buildTargetScalacOptions(
       ScalacOptionsParams params) {
-    return handleRequest("buildTarget/scalacOptions", cc ->
-        buildTargetService.getBuildTargetScalacOptions(params));
+    return handleRequest("buildTarget/scalacOptions", cancelToken ->
+        buildTargetService.getBuildTargetScalacOptions(params, cancelToken));
   }
 
   @Override
@@ -216,46 +221,66 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
   }
 
   private <R> CompletableFuture<R> handleRequest(String methodName,
-      Function<CancelChecker, R> supplier) {
-    return runAsync(methodName, supplier);
-  }
-
-  public <T, R> CompletableFuture<R> handleRequest(String methodName,
-      BiFunction<CancelChecker, T, R> function, T arg) {
-    LOGGER.info("Received request '" + methodName + "'.");
-    return runAsync(methodName, cancelChecker -> function.apply(cancelChecker, arg));
-  }
-
-  private <T> CompletableFuture<T> runAsync(String methodName, Function<CancelChecker, T> request) {
+      Function<CancellationToken, R> request) {
     long startTime = System.nanoTime();
-    return CompletableFutures.computeAsync(request)
-        .thenApply(Either::<Throwable, T>forRight)
-        .exceptionally(Either::forLeft)
+    // create an empty future that will be completed further down
+    CompletableFuture<CancellationToken> cancelTokenFuture = new CompletableFuture<>();
+    // define async run request and handle errors
+    CompletableFuture<R> result = cancelTokenFuture
+        .thenApplyAsync(request)
+        .thenApply(Either::<Throwable, R>forRight)
         .thenCompose(either -> {
-          long elapsedTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+          long elapsedTime = getElapsedTime(startTime);
           return either.isLeft()
-              ? failure(methodName, either.getLeft())
-              : success(methodName, either.getRight(), elapsedTime);
+            ? failure(methodName, either.getLeft(), elapsedTime)
+            : success(methodName, either.getRight(), elapsedTime);
         });
+    // create a Gradle cancellation token
+    CancellationTokenSource cancelTokenSource = GradleConnector.newCancellationTokenSource();
+    CancellationToken cancelToken = cancelTokenSource.token();
+    // ensure Gradle is cancelled when the very last future in the chain is cancelled.
+    Runnable cancel = () -> {
+      cancelTokenSource.cancel();
+      long elapsedTime = getElapsedTime(startTime);
+      logCancelMessage(methodName, elapsedTime);
+    };
+    CancellableFuture<R> wrappedFuture = CancellableFuture.from(result, cancel);
+    // start chain
+    cancelTokenFuture.complete(cancelToken);
+    return wrappedFuture;
+  }
+
+  private long getElapsedTime(long startTime) {
+    return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+  }
+
+  private BspTraceEntity.Builder createMessageBuilder(String methodName, long elapsedTime) {
+    return new BspTraceEntity.Builder()
+      .operationName(escapeMethodName(methodName))
+      .duration(String.valueOf(elapsedTime));
+  }
+
+  private void logCancelMessage(String methodName, long elapsedTime) {
+    BspTraceEntity entity = createMessageBuilder(methodName, elapsedTime).build();
+    String message = String.format("Request cancelled '%s'. Processing request took %d ms.",
+        methodName, elapsedTime);
+    LOGGER.log(Level.INFO, message, entity);
   }
 
   private <T> CompletableFuture<T> success(String methodName, T response, long elapsedTime) {
-    BspTraceEntity entity = new BspTraceEntity.Builder()
-        .operationName(escapeMethodName(methodName))
-        .duration(String.valueOf(elapsedTime))
-        .build();
+    BspTraceEntity entity = createMessageBuilder(methodName, elapsedTime).build();
     String message = String.format("Sending response '%s'. Processing request took %d ms.",
         methodName, elapsedTime);
     LOGGER.log(Level.INFO, message, entity);
     return CompletableFuture.completedFuture(response);
   }
 
-  private <T> CompletableFuture<T> failure(String methodName, Throwable throwable) {
+  private <T> CompletableFuture<T> failure(String methodName, Throwable throwable,
+      long elapsedTime) {
     String stackTrace = ExceptionUtils.getStackTrace(throwable);
     Throwable rootCause = ExceptionUtils.getRootCause(throwable);
     String rootCauseMessage = rootCause != null ? rootCause.getMessage() : null;
-    BspTraceEntity entity = new BspTraceEntity.Builder()
-        .operationName(escapeMethodName(methodName))
+    BspTraceEntity entity = createMessageBuilder(methodName, elapsedTime)
         .trace(stackTrace)
         .rootCauseMessage(rootCauseMessage)
         .build();

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -82,6 +82,7 @@ import ch.epfl.scala.bsp4j.TestParamsDataKind;
 import ch.epfl.scala.bsp4j.TestResult;
 import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 import org.apache.commons.lang3.StringUtils;
+import org.gradle.tooling.CancellationToken;
 
 /**
  * Service to handle build target related BSP requests.
@@ -114,15 +115,15 @@ public class BuildTargetService {
     this.firstTime = true;
   }
 
-  private List<BuildTargetIdentifier> updateBuildTargets() {
+  private List<BuildTargetIdentifier> updateBuildTargets(CancellationToken cancelToken) {
     GradleSourceSets sourceSets = connector.getGradleSourceSets(
-        preferenceManager.getRootUri(), client);
+        preferenceManager.getRootUri(), client, cancelToken);
     return buildTargetManager.store(sourceSets);
   }
 
-  private BuildTargetManager getBuildTargetManager() {
+  private BuildTargetManager getBuildTargetManager(CancellationToken cancelToken) {
     if (firstTime) {
-      updateBuildTargets();
+      updateBuildTargets(cancelToken);
       firstTime = false;
       int buildTargetCount = buildTargetManager.getAllGradleBuildTargets().size();
       Map<String, String> map = TelemetryUtils.getMetadataMap("buildTargetCount",
@@ -136,8 +137,8 @@ public class BuildTargetService {
   /**
    * reload the sourcesets from scratch and notify the BSP client if they have changed.
    */
-  public void reloadWorkspace() {
-    List<BuildTargetIdentifier> changedTargets = updateBuildTargets();
+  public void reloadWorkspace(CancellationToken cancelToken) {
+    List<BuildTargetIdentifier> changedTargets = updateBuildTargets(cancelToken);
     if (!changedTargets.isEmpty()) {
       notifyBuildTargetsChanged(changedTargets);
     }
@@ -151,8 +152,9 @@ public class BuildTargetService {
     client.onBuildTargetDidChange(param);
   }
 
-  private GradleBuildTarget getGradleBuildTarget(BuildTargetIdentifier btId) {
-    return getBuildTargetManager().getGradleBuildTarget(btId);
+  private GradleBuildTarget getGradleBuildTarget(BuildTargetIdentifier btId,
+      CancellationToken cancelToken) {
+    return getBuildTargetManager(cancelToken).getGradleBuildTarget(btId);
   }
 
   public void setClient(BuildClient client) {
@@ -162,39 +164,46 @@ public class BuildTargetService {
   /**
    * Get the build targets of the workspace.
    */
-  public WorkspaceBuildTargetsResult getWorkspaceBuildTargets() {
-    List<GradleBuildTarget> allTargets = getBuildTargetManager().getAllGradleBuildTargets();
+  public WorkspaceBuildTargetsResult getWorkspaceBuildTargets(CancellationToken cancelToken) {
+    List<GradleBuildTarget> allTargets = getBuildTargetManager(cancelToken)
+        .getAllGradleBuildTargets();
     List<BuildTarget> targets = allTargets.stream()
         .map(GradleBuildTarget::getBuildTarget)
         .collect(Collectors.toList());
     return new WorkspaceBuildTargetsResult(targets);
   }
 
+  private boolean isCancelled(CancellationToken cancelToken) {
+    return cancelToken != null && cancelToken.isCancellationRequested();
+  }
+
   /**
    * Get the sources.
    */
-  public SourcesResult getBuildTargetSources(SourcesParams params) {
+  public SourcesResult getBuildTargetSources(SourcesParams params, CancellationToken cancelToken) {
     List<SourcesItem> sourceItems = new ArrayList<>();
     for (BuildTargetIdentifier btId : params.getTargets()) {
-      GradleBuildTarget target = getGradleBuildTarget(btId);
-      if (target == null) {
-        LOGGER.warning("Skip sources collection for the build target: " + btId.getUri()
-            + ". Because it cannot be found in the cache.");
-        continue;
-      }
+      if (!isCancelled(cancelToken)) {
+        GradleBuildTarget target = getGradleBuildTarget(btId, cancelToken);
+        if (target == null) {
+          LOGGER.warning("Skip sources collection for the build target: " + btId.getUri()
+              + ". Because it cannot be found in the cache.");
+          continue;
+        }
 
-      GradleSourceSet sourceSet = target.getSourceSet();
-      List<SourceItem> sources = new ArrayList<>();
-      for (File sourceDir : sourceSet.getSourceDirs()) {
-        sources.add(new SourceItem(sourceDir.toURI().toString(), SourceItemKind.DIRECTORY,
-            false /* generated */));
+        GradleSourceSet sourceSet = target.getSourceSet();
+        List<SourceItem> sources = new ArrayList<>();
+        for (File sourceDir : sourceSet.getSourceDirs()) {
+          sources.add(new SourceItem(sourceDir.toURI().toString(), SourceItemKind.DIRECTORY,
+              false /* generated */));
+        }
+        for (File sourceDir : sourceSet.getGeneratedSourceDirs()) {
+          sources.add(new SourceItem(sourceDir.toURI().toString(), SourceItemKind.DIRECTORY,
+              true /* generated */));
+        }
+        SourcesItem item = new SourcesItem(btId, sources);
+        sourceItems.add(item);
       }
-      for (File sourceDir : sourceSet.getGeneratedSourceDirs()) {
-        sources.add(new SourceItem(sourceDir.toURI().toString(), SourceItemKind.DIRECTORY,
-            true /* generated */));
-      }
-      SourcesItem item = new SourcesItem(btId, sources);
-      sourceItems.add(item);
     }
     return new SourcesResult(sourceItems);
   }
@@ -202,23 +211,26 @@ public class BuildTargetService {
   /**
    * Get the resources.
    */
-  public ResourcesResult getBuildTargetResources(ResourcesParams params) {
+  public ResourcesResult getBuildTargetResources(ResourcesParams params,
+      CancellationToken cancelToken) {
     List<ResourcesItem> items = new ArrayList<>();
     for (BuildTargetIdentifier btId : params.getTargets()) {
-      GradleBuildTarget target = getGradleBuildTarget(btId);
-      if (target == null) {
-        LOGGER.warning("Skip resources collection for the build target: " + btId.getUri()
-            + ". Because it cannot be found in the cache.");
-        continue;
-      }
+      if (!isCancelled(cancelToken)) {
+        GradleBuildTarget target = getGradleBuildTarget(btId, cancelToken);
+        if (target == null) {
+          LOGGER.warning("Skip resources collection for the build target: " + btId.getUri()
+              + ". Because it cannot be found in the cache.");
+          continue;
+        }
 
-      GradleSourceSet sourceSet = target.getSourceSet();
-      List<String> resources = new ArrayList<>();
-      for (File resourceDir : sourceSet.getResourceDirs()) {
-        resources.add(resourceDir.toURI().toString());
+        GradleSourceSet sourceSet = target.getSourceSet();
+        List<String> resources = new ArrayList<>();
+        for (File resourceDir : sourceSet.getResourceDirs()) {
+          resources.add(resourceDir.toURI().toString());
+        }
+        ResourcesItem item = new ResourcesItem(btId, resources);
+        items.add(item);
       }
-      ResourcesItem item = new ResourcesItem(btId, resources);
-      items.add(item);
     }
     return new ResourcesResult(items);
   }
@@ -226,43 +238,46 @@ public class BuildTargetService {
   /**
    * Get the output paths.
    */
-  public OutputPathsResult getBuildTargetOutputPaths(OutputPathsParams params) {
+  public OutputPathsResult getBuildTargetOutputPaths(OutputPathsParams params,
+      CancellationToken cancelToken) {
     List<OutputPathsItem> items = new ArrayList<>();
     for (BuildTargetIdentifier btId : params.getTargets()) {
-      GradleBuildTarget target = getGradleBuildTarget(btId);
-      if (target == null) {
-        LOGGER.warning("Skip output collection for the build target: " + btId.getUri()
-            + ". Because it cannot be found in the cache.");
-        continue;
-      }
+      if (!isCancelled(cancelToken)) {
+        GradleBuildTarget target = getGradleBuildTarget(btId, cancelToken);
+        if (target == null) {
+          LOGGER.warning("Skip output collection for the build target: " + btId.getUri()
+              + ". Because it cannot be found in the cache.");
+          continue;
+        }
 
-      GradleSourceSet sourceSet = target.getSourceSet();
-      List<OutputPathItem> outputPaths = new ArrayList<>();
-      // Due to the BSP spec does not support additional flags for each output path,
-      // we will leverage the query of the uri to mark whether this is a source/resource
-      // output path.
-      // TODO: file a BSP spec issue to support additional flags for each output path.
+        GradleSourceSet sourceSet = target.getSourceSet();
+        List<OutputPathItem> outputPaths = new ArrayList<>();
+        // Due to the BSP spec does not support additional flags for each output path,
+        // we will leverage the query of the uri to mark whether this is a source/resource
+        // output path.
+        // TODO: file a BSP spec issue to support additional flags for each output path.
 
-      Set<File> sourceOutputDirs = sourceSet.getSourceOutputDirs();
-      if (sourceOutputDirs != null) {
-        for (File sourceOutputDir : sourceOutputDirs) {
+        Set<File> sourceOutputDirs = sourceSet.getSourceOutputDirs();
+        if (sourceOutputDirs != null) {
+          for (File sourceOutputDir : sourceOutputDirs) {
+            outputPaths.add(new OutputPathItem(
+                sourceOutputDir.toURI().toString() + "?kind=source",
+                OutputPathItemKind.DIRECTORY
+            ));
+          }
+        }
+
+        File resourceOutputDir = sourceSet.getResourceOutputDir();
+        if (resourceOutputDir != null) {
           outputPaths.add(new OutputPathItem(
-              sourceOutputDir.toURI().toString() + "?kind=source",
+              resourceOutputDir.toURI().toString() + "?kind=resource",
               OutputPathItemKind.DIRECTORY
           ));
         }
-      }
 
-      File resourceOutputDir = sourceSet.getResourceOutputDir();
-      if (resourceOutputDir != null) {
-        outputPaths.add(new OutputPathItem(
-            resourceOutputDir.toURI().toString() + "?kind=resource",
-            OutputPathItemKind.DIRECTORY
-        ));
+        OutputPathsItem item = new OutputPathsItem(btId, outputPaths);
+        items.add(item);
       }
-
-      OutputPathsItem item = new OutputPathsItem(btId, outputPaths);
-      items.add(item);
     }
     return new OutputPathsResult(items);
   }
@@ -270,27 +285,30 @@ public class BuildTargetService {
   /**
    * Get artifacts dependencies - old way.
    */
-  public DependencySourcesResult getBuildTargetDependencySources(DependencySourcesParams params) {
+  public DependencySourcesResult getBuildTargetDependencySources(DependencySourcesParams params,
+      CancellationToken cancelToken) {
     List<DependencySourcesItem> items = new ArrayList<>();
     for (BuildTargetIdentifier btId : params.getTargets()) {
-      GradleBuildTarget target = getGradleBuildTarget(btId);
-      if (target == null) {
-        LOGGER.warning("Skip output collection for the build target: " + btId.getUri()
-                + ". Because it cannot be found in the cache.");
-        continue;
-      }
+      if (!isCancelled(cancelToken)) {
+        GradleBuildTarget target = getGradleBuildTarget(btId, cancelToken);
+        if (target == null) {
+          LOGGER.warning("Skip output collection for the build target: " + btId.getUri()
+                  + ". Because it cannot be found in the cache.");
+          continue;
+        }
 
-      GradleSourceSet sourceSet = target.getSourceSet();
-      List<String> sources = new ArrayList<>();
-      for (GradleModuleDependency dep : sourceSet.getModuleDependencies()) {
-        List<String> artifacts = dep.getArtifacts().stream()
-                .filter(a -> "sources".equals(a.getClassifier()))
-                .map(a -> a.getUri().toString())
-                .collect(Collectors.toList());
-        sources.addAll(artifacts);
-      }
+        GradleSourceSet sourceSet = target.getSourceSet();
+        List<String> sources = new ArrayList<>();
+        for (GradleModuleDependency dep : sourceSet.getModuleDependencies()) {
+          List<String> artifacts = dep.getArtifacts().stream()
+                  .filter(a -> "sources".equals(a.getClassifier()))
+                  .map(a -> a.getUri().toString())
+                  .collect(Collectors.toList());
+          sources.addAll(artifacts);
+        }
 
-      items.add(new DependencySourcesItem(btId, sources));
+        items.add(new DependencySourcesItem(btId, sources));
+      }
     }
     return new DependencySourcesResult(items);
   }
@@ -298,39 +316,42 @@ public class BuildTargetService {
   /**
    * Get artifacts dependencies.
    */
-  public DependencyModulesResult getBuildTargetDependencyModules(DependencyModulesParams params) {
+  public DependencyModulesResult getBuildTargetDependencyModules(DependencyModulesParams params,
+      CancellationToken cancelToken) {
     List<DependencyModulesItem> items = new ArrayList<>();
     for (BuildTargetIdentifier btId : params.getTargets()) {
-      GradleBuildTarget target = getGradleBuildTarget(btId);
-      if (target == null) {
-        LOGGER.warning("Skip output collection for the build target: " + btId.getUri()
-            + ". Because it cannot be found in the cache.");
-        continue;
-      }
+      if (!isCancelled(cancelToken)) {
+        GradleBuildTarget target = getGradleBuildTarget(btId, cancelToken);
+        if (target == null) {
+          LOGGER.warning("Skip output collection for the build target: " + btId.getUri()
+              + ". Because it cannot be found in the cache.");
+          continue;
+        }
 
-      GradleSourceSet sourceSet = target.getSourceSet();
-      List<DependencyModule> modules = new ArrayList<>();
-      for (GradleModuleDependency dep : sourceSet.getModuleDependencies()) {
-        DependencyModule module = new DependencyModule(dep.getModule(), dep.getVersion());
-        module.setDataKind(MAVEN_DATA_KIND);
-        List<MavenDependencyModuleArtifact> artifacts = dep.getArtifacts().stream().map(a -> {
-          MavenDependencyModuleArtifact artifact = new MavenDependencyModuleArtifact(
-              a.getUri().toString());
-          artifact.setClassifier(a.getClassifier());
-          return artifact;
-        }).collect(Collectors.toList());
-        MavenDependencyModule mavenModule = new MavenDependencyModule(
-            dep.getGroup(),
-            dep.getModule(),
-            dep.getVersion(),
-            artifacts
-        );
-        module.setData(mavenModule);
-        modules.add(module);
-      }
+        GradleSourceSet sourceSet = target.getSourceSet();
+        List<DependencyModule> modules = new ArrayList<>();
+        for (GradleModuleDependency dep : sourceSet.getModuleDependencies()) {
+          DependencyModule module = new DependencyModule(dep.getModule(), dep.getVersion());
+          module.setDataKind(MAVEN_DATA_KIND);
+          List<MavenDependencyModuleArtifact> artifacts = dep.getArtifacts().stream().map(a -> {
+            MavenDependencyModuleArtifact artifact = new MavenDependencyModuleArtifact(
+                a.getUri().toString());
+            artifact.setClassifier(a.getClassifier());
+            return artifact;
+          }).collect(Collectors.toList());
+          MavenDependencyModule mavenModule = new MavenDependencyModule(
+              dep.getGroup(),
+              dep.getModule(),
+              dep.getVersion(),
+              artifacts
+          );
+          module.setData(mavenModule);
+          modules.add(module);
+        }
 
-      DependencyModulesItem item = new DependencyModulesItem(btId, modules);
-      items.add(item);
+        DependencyModulesItem item = new DependencyModulesItem(btId, modules);
+        items.add(item);
+      }
     }
     return new DependencyModulesResult(items);
   }
@@ -338,21 +359,27 @@ public class BuildTargetService {
   /**
    * Compile the build targets.
    */
-  public CompileResult compile(CompileParams params) {
+  public CompileResult compile(CompileParams params, CancellationToken cancelToken) {
     if (params.getTargets().isEmpty()) {
       return new CompileResult(StatusCode.OK);
     } else {
       ProgressReporter reporter = new CompileProgressReporter(client,
           params.getOriginId(), getFullTaskPathMap());
-      StatusCode code = runTasks(params.getTargets(), this::getBuildTaskName, reporter);
+      StatusCode code = runTasks(params.getTargets(), btId -> getBuildTaskName(btId, cancelToken),
+          reporter, cancelToken);
       CompileResult result = new CompileResult(code);
       result.setOriginId(params.getOriginId());
 
       // Schedule a task to refetch the build targets after compilation, this is to
       // auto detect the source roots changes for those code generation framework,
       // such as Protocol Buffer.
+      // This doesn't take into account compilation triggered from running main class or tests.
+      // This cannot be cancelled as it's not triggered from a BSP Client so the CompletableFuture
+      // is left in the ether.
+      // It could be shifted into the `GradleBuildServer#buildTargetCompile` and chained onto that
+      // result but that would delay the CompileResult
       if (!Boolean.getBoolean("bsp.plugin.reloadworkspace.disabled")) {
-        CompletableFuture.runAsync(this::reloadWorkspace);
+        CompletableFuture.runAsync(() -> reloadWorkspace(null));
       }
       return result;
     }
@@ -361,9 +388,10 @@ public class BuildTargetService {
   /**
    * clean the build targets.
    */
-  public CleanCacheResult cleanCache(CleanCacheParams params) {
+  public CleanCacheResult cleanCache(CleanCacheParams params, CancellationToken cancelToken) {
     ProgressReporter reporter = new DefaultProgressReporter(client);
-    StatusCode code = runTasks(params.getTargets(), this::getCleanTaskName, reporter);
+    StatusCode code = runTasks(params.getTargets(), btId -> getCleanTaskName(btId, cancelToken),
+        reporter, cancelToken);
     return new CleanCacheResult(null, code == StatusCode.OK);
   }
 
@@ -388,16 +416,19 @@ public class BuildTargetService {
    */
   private StatusCode runTasks(List<BuildTargetIdentifier> targets,
       Function<BuildTargetIdentifier, String> taskNameCreator,
-      ProgressReporter reporter) {
-    Map<URI, Set<BuildTargetIdentifier>> groupedTargets = groupBuildTargetsByRootDir(targets);
+      ProgressReporter reporter, CancellationToken cancelToken) {
+    Map<URI, Set<BuildTargetIdentifier>> groupedTargets =
+        groupBuildTargetsByRootDir(targets, cancelToken);
     StatusCode code = StatusCode.OK;
     for (Map.Entry<URI, Set<BuildTargetIdentifier>> entry : groupedTargets.entrySet()) {
-      // remove duplicates as some tasks will have the same name for each sourceset e.g. clean.
-      String[] tasks = entry.getValue().stream().map(taskNameCreator).distinct()
-        .toArray(String[]::new);
-      code = connector.runTasks(entry.getKey(), reporter, tasks);
-      if (code == StatusCode.ERROR) {
-        break;
+      if (!isCancelled(cancelToken)) {
+        // remove duplicates as some tasks will have the same name for each sourceset e.g. clean.
+        String[] tasks = entry.getValue().stream().map(taskNameCreator).distinct()
+          .toArray(String[]::new);
+        code = connector.runTasks(entry.getKey(), reporter, tasks, cancelToken);
+        if (code == StatusCode.ERROR) {
+          break;
+        }
       }
     }
     return code;
@@ -406,38 +437,41 @@ public class BuildTargetService {
   /**
    * Get the Java compiler options.
    */
-  public JavacOptionsResult getBuildTargetJavacOptions(JavacOptionsParams params) {
+  public JavacOptionsResult getBuildTargetJavacOptions(JavacOptionsParams params,
+      CancellationToken cancelToken) {
     List<JavacOptionsItem> items = new ArrayList<>();
     for (BuildTargetIdentifier btId : params.getTargets()) {
-      GradleBuildTarget target = getGradleBuildTarget(btId);
-      if (target == null) {
-        LOGGER.warning("Skip javac options collection for the build target: " + btId.getUri()
-            + ". Because it cannot be found in the cache.");
-        continue;
-      }
+      if (!isCancelled(cancelToken)) {
+        GradleBuildTarget target = getGradleBuildTarget(btId, cancelToken);
+        if (target == null) {
+          LOGGER.warning("Skip javac options collection for the build target: " + btId.getUri()
+              + ". Because it cannot be found in the cache.");
+          continue;
+        }
 
-      GradleSourceSet sourceSet = target.getSourceSet();
-      JavaExtension javaExtension = SupportedLanguages.JAVA.getExtension(sourceSet);
-      if (javaExtension == null) {
-        LOGGER.warning("Skip javac options collection for the build target: " + btId.getUri()
-            + ". Because the java extension cannot be found from source set.");
-        continue;
+        GradleSourceSet sourceSet = target.getSourceSet();
+        JavaExtension javaExtension = SupportedLanguages.JAVA.getExtension(sourceSet);
+        if (javaExtension == null) {
+          LOGGER.warning("Skip javac options collection for the build target: " + btId.getUri()
+              + ". Because the java extension cannot be found from source set.");
+          continue;
+        }
+        List<String> classpath = sourceSet.getCompileClasspath().stream()
+            .map(file -> file.toURI().toString())
+            .collect(Collectors.toList());
+        String classesDir;
+        if (javaExtension.getClassesDir() != null) {
+          classesDir = javaExtension.getClassesDir().toURI().toString();
+        } else {
+          classesDir = "";
+        }
+        items.add(new JavacOptionsItem(
+            btId,
+            javaExtension.getCompilerArgs(),
+            classpath,
+            classesDir
+        ));
       }
-      List<String> classpath = sourceSet.getCompileClasspath().stream()
-          .map(file -> file.toURI().toString())
-          .collect(Collectors.toList());
-      String classesDir;
-      if (javaExtension.getClassesDir() != null) {
-        classesDir = javaExtension.getClassesDir().toURI().toString();
-      } else {
-        classesDir = "";
-      }
-      items.add(new JavacOptionsItem(
-          btId,
-          javaExtension.getCompilerArgs(),
-          classpath,
-          classesDir
-      ));
     }
     return new JavacOptionsResult(items);
   }
@@ -445,38 +479,41 @@ public class BuildTargetService {
   /**
    * Get the Scala compiler options.
    */
-  public ScalacOptionsResult getBuildTargetScalacOptions(ScalacOptionsParams params) {
+  public ScalacOptionsResult getBuildTargetScalacOptions(ScalacOptionsParams params,
+      CancellationToken cancelToken) {
     List<ScalacOptionsItem> items = new ArrayList<>();
     for (BuildTargetIdentifier btId : params.getTargets()) {
-      GradleBuildTarget target = getGradleBuildTarget(btId);
-      if (target == null) {
-        LOGGER.warning("Skip scalac options collection for the build target: " + btId.getUri()
-            + ". Because it cannot be found in the cache.");
-        continue;
-      }
+      if (!isCancelled(cancelToken)) {
+        GradleBuildTarget target = getGradleBuildTarget(btId, cancelToken);
+        if (target == null) {
+          LOGGER.warning("Skip scalac options collection for the build target: " + btId.getUri()
+              + ". Because it cannot be found in the cache.");
+          continue;
+        }
 
-      GradleSourceSet sourceSet = target.getSourceSet();
-      ScalaExtension scalaExtension = SupportedLanguages.SCALA.getExtension(sourceSet);
-      if (scalaExtension == null) {
-        LOGGER.warning("Skip scalac options collection for the build target: " + btId.getUri()
-                + ". Because the scalac extension cannot be found from source set.");
-        continue;
+        GradleSourceSet sourceSet = target.getSourceSet();
+        ScalaExtension scalaExtension = SupportedLanguages.SCALA.getExtension(sourceSet);
+        if (scalaExtension == null) {
+          LOGGER.warning("Skip scalac options collection for the build target: " + btId.getUri()
+                  + ". Because the scalac extension cannot be found from source set.");
+          continue;
+        }
+        List<String> classpath = sourceSet.getCompileClasspath().stream()
+            .map(file -> file.toURI().toString())
+            .collect(Collectors.toList());
+        String classesDir;
+        if (scalaExtension.getClassesDir() != null) {
+          classesDir = scalaExtension.getClassesDir().toURI().toString();
+        } else {
+          classesDir = "";
+        }
+        items.add(new ScalacOptionsItem(
+            btId,
+            scalaExtension.getScalaCompilerArgs(),
+            classpath,
+            classesDir
+        ));
       }
-      List<String> classpath = sourceSet.getCompileClasspath().stream()
-          .map(file -> file.toURI().toString())
-          .collect(Collectors.toList());
-      String classesDir;
-      if (scalaExtension.getClassesDir() != null) {
-        classesDir = scalaExtension.getClassesDir().toURI().toString();
-      } else {
-        classesDir = "";
-      }
-      items.add(new ScalacOptionsItem(
-          btId,
-          scalaExtension.getScalaCompilerArgs(),
-          classpath,
-          classesDir
-      ));
     }
     return new ScalacOptionsResult(items);
   }
@@ -484,71 +521,76 @@ public class BuildTargetService {
   /**
    * Run the test classes.
    */
-  public TestResult buildTargetTest(TestParams params) {
+  public TestResult buildTargetTest(TestParams params, CancellationToken cancelToken) {
     TestResult testResult = new TestResult(StatusCode.OK);
     testResult.setOriginId(params.getOriginId());
     // running tests can trigger compilation that must be reported on
     CompileProgressReporter compileProgressReporter = new CompileProgressReporter(client,
             params.getOriginId(), getFullTaskPathMap());
     Map<URI, Set<BuildTargetIdentifier>> groupedTargets =
-        groupBuildTargetsByRootDir(params.getTargets());
+        groupBuildTargetsByRootDir(params.getTargets(), cancelToken);
     for (Map.Entry<URI, Set<BuildTargetIdentifier>> entry : groupedTargets.entrySet()) {
-      // TODO ideally BSP would have a jvmTestEnv style testkind for executing tests, not scala.
       StatusCode statusCode;
-      if (TestParamsDataKind.SCALA_TEST.equals(params.getDataKind())) {
-        // ScalaTestParams is for a list of classes only
-        ScalaTestParams testParams = JsonUtils.toModel(params.getData(), ScalaTestParams.class);
-        Map<BuildTargetIdentifier, Map<String, Set<String>>> testClasses = new HashMap<>();
-        for (ScalaTestClassesItem testClassesItem : testParams.getTestClasses()) {
-          Map<String, Set<String>> classesMethods = new HashMap<>();
-          for (String classNames : testClassesItem.getClasses()) {
-            classesMethods.put(classNames, null);
-          }
-          testClasses.put(testClassesItem.getTarget(), classesMethods);
-        }
-        statusCode = connector.runTests(entry.getKey(), testClasses, testParams.getJvmOptions(),
-            params.getArguments(), null, client, params.getOriginId(),
-            compileProgressReporter);
-      } else if ("scala-test-suites-selection".equals(params.getDataKind())) {
-        // ScalaTestSuites is for a list of classes + methods
-        // Since it doesn't supply the specific BuildTarget we require a single
-        // build target in the params and reject any request that doesn't match this
-        if (params.getTargets().size() != 1) {
-          LOGGER.warning("Test params with Test Data Kind " + params.getDataKind()
-              + " must contain only 1 build target");
-          statusCode = StatusCode.ERROR;
-        } else {
-          ScalaTestSuites testSuites = JsonUtils.toModel(params.getData(), ScalaTestSuites.class);
-          Map<String, String> envVars = null;
-          boolean argsValid = true;
-          if (testSuites.getEnvironmentVariables() != null) {
-            // arg is of the form KEY=VALUE
-            List<String[]> splitArgs = testSuites.getEnvironmentVariables()
-                .stream()
-                .map(arg -> arg.split("="))
-                .collect(Collectors.toList());
-            argsValid = splitArgs.stream().allMatch(arg -> arg.length == 2);
-            if (argsValid) {
-              envVars = splitArgs.stream().collect(Collectors.toMap(arg -> arg[0], arg -> arg[1]));
+      if (!isCancelled(cancelToken)) {
+        // TODO ideally BSP would have a jvmTestEnv style testkind for executing tests, not scala.
+        if (TestParamsDataKind.SCALA_TEST.equals(params.getDataKind())) {
+          // ScalaTestParams is for a list of classes only
+          ScalaTestParams testParams = JsonUtils.toModel(params.getData(), ScalaTestParams.class);
+          Map<BuildTargetIdentifier, Map<String, Set<String>>> testClasses = new HashMap<>();
+          for (ScalaTestClassesItem testClassesItem : testParams.getTestClasses()) {
+            Map<String, Set<String>> classesMethods = new HashMap<>();
+            for (String classNames : testClassesItem.getClasses()) {
+              classesMethods.put(classNames, null);
             }
+            testClasses.put(testClassesItem.getTarget(), classesMethods);
           }
-          if (!argsValid) {
-            LOGGER.warning("Test params arguments must each be in the form KEY=VALUE. "
-                + testSuites.getEnvironmentVariables());
+          statusCode = connector.runTests(entry.getKey(), testClasses, testParams.getJvmOptions(),
+              params.getArguments(), null, client, params.getOriginId(),
+              compileProgressReporter, cancelToken);
+        } else if ("scala-test-suites-selection".equals(params.getDataKind())) {
+          // ScalaTestSuites is for a list of classes + methods
+          // Since it doesn't supply the specific BuildTarget we require a single
+          // build target in the params and reject any request that doesn't match this
+          if (params.getTargets().size() != 1) {
+            LOGGER.warning("Test params with Test Data Kind " + params.getDataKind()
+                + " must contain only 1 build target");
             statusCode = StatusCode.ERROR;
           } else {
-            Map<String, Set<String>> classesMethods = new HashMap<>();
-            for (ScalaTestSuiteSelection testSuiteSelection : testSuites.getSuites()) {
-              Set<String> methods = classesMethods
-                  .computeIfAbsent(testSuiteSelection.getClassName(), k -> new HashSet<>());
-              methods.addAll(testSuiteSelection.getTests());
+            ScalaTestSuites testSuites = JsonUtils.toModel(params.getData(), ScalaTestSuites.class);
+            Map<String, String> envVars = null;
+            boolean argsValid = true;
+            if (testSuites.getEnvironmentVariables() != null) {
+              // arg is of the form KEY=VALUE
+              List<String[]> splitArgs = testSuites.getEnvironmentVariables()
+                  .stream()
+                  .map(arg -> arg.split("="))
+                  .collect(Collectors.toList());
+              argsValid = splitArgs.stream().allMatch(arg -> arg.length == 2);
+              if (argsValid) {
+                envVars = splitArgs.stream()
+                  .collect(Collectors.toMap(arg -> arg[0], arg -> arg[1]));
+              }
             }
-            Map<BuildTargetIdentifier, Map<String, Set<String>>> testClasses = new HashMap<>();
-            testClasses.put(params.getTargets().get(0), classesMethods);
-            statusCode = connector.runTests(entry.getKey(), testClasses, testSuites.getJvmOptions(),
-              params.getArguments(), envVars, client, params.getOriginId(),
-              compileProgressReporter);
+            if (!argsValid) {
+              LOGGER.warning("Test params arguments must each be in the form KEY=VALUE. "
+                  + testSuites.getEnvironmentVariables());
+              statusCode = StatusCode.ERROR;
+            } else {
+              Map<String, Set<String>> classesMethods = new HashMap<>();
+              for (ScalaTestSuiteSelection testSuiteSelection : testSuites.getSuites()) {
+                Set<String> methods = classesMethods
+                    .computeIfAbsent(testSuiteSelection.getClassName(), k -> new HashSet<>());
+                methods.addAll(testSuiteSelection.getTests());
+              }
+              Map<BuildTargetIdentifier, Map<String, Set<String>>> testClasses = new HashMap<>();
+              testClasses.put(params.getTargets().get(0), classesMethods);
+              statusCode = connector.runTests(entry.getKey(), testClasses,
+                testSuites.getJvmOptions(), params.getArguments(), envVars, client,
+                params.getOriginId(), compileProgressReporter, cancelToken);
+            }
           }
+        } else {
+          statusCode = StatusCode.CANCELLED;
         }
       } else {
         LOGGER.warning("Test Data Kind " + params.getDataKind() + " not supported");
@@ -568,15 +610,16 @@ public class BuildTargetService {
    * in one single call.
    */
   private Map<URI, Set<BuildTargetIdentifier>> groupBuildTargetsByRootDir(
-      List<BuildTargetIdentifier> targets
-  ) {
+      List<BuildTargetIdentifier> targets, CancellationToken cancelToken) {
     Map<URI, Set<BuildTargetIdentifier>> groupedTargets = new HashMap<>();
     for (BuildTargetIdentifier btId : targets) {
-      URI projectUri = getRootProjectUri(btId);
-      if (projectUri == null) {
-        continue;
+      if (!isCancelled(cancelToken)) {
+        URI projectUri = getRootProjectUri(btId, cancelToken);
+        if (projectUri == null) {
+          continue;
+        }
+        groupedTargets.computeIfAbsent(projectUri, k -> new HashSet<>()).add(btId);
       }
-      groupedTargets.computeIfAbsent(projectUri, k -> new HashSet<>()).add(btId);
     }
     return groupedTargets;
   }
@@ -585,8 +628,8 @@ public class BuildTargetService {
    * Try to get the project root directory uri. If root directory is not available,
    * return the uri of the build target.
    */
-  private URI getRootProjectUri(BuildTargetIdentifier btId) {
-    GradleBuildTarget gradleBuildTarget = getGradleBuildTarget(btId);
+  private URI getRootProjectUri(BuildTargetIdentifier btId, CancellationToken cancelToken) {
+    GradleBuildTarget gradleBuildTarget = getGradleBuildTarget(btId, cancelToken);
     if (gradleBuildTarget == null) {
       // TODO: https://github.com/microsoft/build-server-for-gradle/issues/50
       throw new IllegalArgumentException("The build target does not exist: " + btId.getUri());
@@ -603,8 +646,8 @@ public class BuildTargetService {
    * Return a source set task name.
    */
   private String getProjectTaskName(BuildTargetIdentifier btId, String title,
-      Function<GradleSourceSet, String> creator) {
-    GradleBuildTarget gradleBuildTarget = getGradleBuildTarget(btId);
+      Function<GradleSourceSet, String> creator, CancellationToken cancelToken) {
+    GradleBuildTarget gradleBuildTarget = getGradleBuildTarget(btId, cancelToken);
     if (gradleBuildTarget == null) {
       // TODO: https://github.com/microsoft/build-server-for-gradle/issues/50
       throw new IllegalArgumentException("The build target does not exist: " + btId.getUri());
@@ -620,14 +663,14 @@ public class BuildTargetService {
   /**
    * Return the build task name - [project path]:[task].
    */
-  private String getBuildTaskName(BuildTargetIdentifier btId) {
-    return getProjectTaskName(btId, "classes", GradleSourceSet::getClassesTaskName);
+  private String getBuildTaskName(BuildTargetIdentifier btId, CancellationToken cancelToken) {
+    return getProjectTaskName(btId, "classes", GradleSourceSet::getClassesTaskName, cancelToken);
   }
 
   /**
    * Return the clean task name - [project path]:[task].
    */
-  private String getCleanTaskName(BuildTargetIdentifier btId) {
-    return getProjectTaskName(btId, "clean", GradleSourceSet::getCleanTaskName);
+  private String getCleanTaskName(BuildTargetIdentifier btId, CancellationToken cancelToken) {
+    return getProjectTaskName(btId, "clean", GradleSourceSet::getCleanTaskName, cancelToken);
   }
 }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
@@ -14,6 +14,7 @@ import java.util.Map.Entry;
 import java.util.logging.Level;
 
 import org.apache.commons.lang3.StringUtils;
+import org.gradle.tooling.CancellationToken;
 
 import com.microsoft.java.bs.core.Constants;
 import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
@@ -38,9 +39,9 @@ public class LifecycleService {
 
   private Status status = Status.UNINITIALIZED;
 
-  private GradleApiConnector connector;
+  private final GradleApiConnector connector;
 
-  private PreferenceManager preferenceManager;
+  private final PreferenceManager preferenceManager;
 
   /**
    * Constructor for {@link LifecycleService}.
@@ -53,8 +54,9 @@ public class LifecycleService {
   /**
    * Initialize the build server.
    */
-  public InitializeBuildResult initializeServer(InitializeBuildParams params) {
-    initializePreferenceManager(params);
+  public InitializeBuildResult initializeServer(InitializeBuildParams params,
+      CancellationToken cancelToken) {
+    initializePreferenceManager(params, cancelToken);
 
     BuildServerCapabilities capabilities = initializeServerCapabilities();
     return new InitializeBuildResult(
@@ -65,7 +67,7 @@ public class LifecycleService {
     );
   }
 
-  void initializePreferenceManager(InitializeBuildParams params) {
+  void initializePreferenceManager(InitializeBuildParams params, CancellationToken cancelToken) {
     URI rootUri = UriUtils.getUriFromString(params.getRootUri());
     preferenceManager.setRootUri(rootUri);
     preferenceManager.setClientSupportedLanguages(params.getCapabilities().getLanguageIds());
@@ -77,7 +79,7 @@ public class LifecycleService {
     }
 
     preferenceManager.setPreferences(preferences);
-    updateGradleJavaHomeIfNecessary(rootUri);
+    updateGradleJavaHomeIfNecessary(rootUri, cancelToken);
   }
 
   private BuildServerCapabilities initializeServerCapabilities() {
@@ -131,7 +133,7 @@ public class LifecycleService {
    *
    * <p>The JDK installation path string will be set to {@link Preferences#gradleJavaHome}.
    */
-  private void updateGradleJavaHomeIfNecessary(URI rootUri) {
+  private void updateGradleJavaHomeIfNecessary(URI rootUri, CancellationToken cancelToken) {
     Preferences preferences = preferenceManager.getPreferences();
     if (preferences.getJdks() == null || preferences.getJdks().isEmpty()) {
       return;
@@ -145,7 +147,7 @@ public class LifecycleService {
       if (buildKind == GradleBuildKind.SPECIFIED_VERSION) {
         gradleVersion = preferences.getGradleVersion();
       } else {
-        gradleVersion = connector.getGradleVersion(rootUri);
+        gradleVersion = connector.getGradleVersion(rootUri, cancelToken);
       }
 
       if (StringUtils.isNotBlank(gradleVersion)) {

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/utils/concurrent/CancellableFuture.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/utils/concurrent/CancellableFuture.java
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.core.internal.utils.concurrent;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link CompletableFuture} implementation that triggers a {@link Runnable} when cancelled.
+ * This does not cancel any other {@link CompletableFuture} in the chain.
+ * Reference:
+ * https://github.com/JetBrains/intellij-scala/blob/9395de0f3ae6e4c3f7411edabc5374e6595162f5/bsp/src/org/jetbrains/bsp/protocol/session/CancellableFuture.java
+ */
+public class CancellableFuture<T> extends CompletableFuture<T> {
+  
+  private final Runnable cancelRunnable;
+
+  private CancellableFuture(Runnable cancelRunnable) {
+    this.cancelRunnable = cancelRunnable;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    if (cancelRunnable != null) {
+      cancelRunnable.run();
+    }
+    return super.cancel(mayInterruptIfRunning);
+  }
+
+  @Override
+  public <U> CancellableFuture<U> newIncompleteFuture() {
+    return new CancellableFuture<>(cancelRunnable);
+  }
+
+  /**
+   * Add CancellableFuture to endOfChain so it can pass on the endOfChain result.
+   *
+   * @param <U> endOfChain result type
+   * @param endOfChain end of a chain of CompletableFutures
+   * @param cancelRunnable code to run when cancellation is triggered
+   * @return CancellableFuture
+   */
+  public static <U> CancellableFuture<U> from(CompletableFuture<U> endOfChain,
+      Runnable cancelRunnable) {
+    CancellableFuture<U> result = new CancellableFuture<>(cancelRunnable);
+    endOfChain.whenComplete((value, error) -> {
+      if (error != null) {
+        result.completeExceptionally(error);
+      } else {
+        result.complete(value);
+      }
+    });
+    return result;
+  }
+}

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -62,13 +62,15 @@ class GradleApiConnectorTest {
   }
   
   private GradleSourceSets getGradleSourceSets(File projectDir) {
-    return withConnector(connector -> connector.getGradleSourceSets(projectDir.toURI(), null));
+    return withConnector(connector -> connector.getGradleSourceSets(projectDir.toURI(),
+        null, null));
   }
 
   @Test
   void testGetGradleVersion() {
     File projectDir = projectPath.resolve("gradle-4.3-with-wrapper").toFile();
-    String version = withConnector(connector -> connector.getGradleVersion(projectDir.toURI()));
+    String version = withConnector(connector -> connector.getGradleVersion(projectDir.toURI(),
+        null));
     assertEquals("4.3", version);
   }
 
@@ -309,7 +311,8 @@ class GradleApiConnectorTest {
   void testBuildTargetTest() {
     File projectDir = projectPath.resolve("java-tests").toFile();
     withConnector(connector -> {
-      GradleSourceSets gradleSourceSets = connector.getGradleSourceSets(projectDir.toURI(), null);
+      GradleSourceSets gradleSourceSets = connector.getGradleSourceSets(projectDir.toURI(),
+          null, null);
       GradleSourceSet testSourceSet =
           findSourceSet(gradleSourceSets, "java-tests [test]");
       Map<BuildTargetIdentifier, Map<String, Set<String>>> testClassesMap = new HashMap<>();
@@ -319,12 +322,12 @@ class GradleApiConnectorTest {
       Set<String> methods = new HashSet<>();
       classes.put("com.example.project.PassingTests", methods);
       StatusCode passingTest = connector.runTests(projectDir.toURI(),
-          testClassesMap, null, null, null, null, null, null);
+          testClassesMap, null, null, null, null, null, null, null);
       assertEquals(StatusCode.OK, passingTest);
       classes.clear();
       classes.put("com.example.project.FailingTests", methods);
       StatusCode failingTest = connector.runTests(projectDir.toURI(),
-          testClassesMap, null, null, null, null, null, null);
+          testClassesMap, null, null, null, null, null, null, null);
       assertEquals(StatusCode.ERROR, failingTest);
       return null;
     });

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/server/BuildTargetServerIntegrationTest.java
@@ -21,8 +21,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.IntSupplier;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import ch.epfl.scala.bsp4j.BuildClient;
@@ -72,11 +74,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.microsoft.java.bs.core.Launcher;
-import com.microsoft.java.bs.core.internal.gradle.GradleApiConnector;
-import com.microsoft.java.bs.core.internal.managers.BuildTargetManager;
-import com.microsoft.java.bs.core.internal.managers.PreferenceManager;
-import com.microsoft.java.bs.core.internal.services.BuildTargetService;
-import com.microsoft.java.bs.core.internal.services.LifecycleService;
 import com.microsoft.java.bs.core.internal.utils.JsonUtils;
 import com.microsoft.java.bs.gradle.model.SupportedLanguages;
 
@@ -189,12 +186,11 @@ class BuildTargetServerIntegrationTest {
                   .collect(Collectors.joining("\n"))));
     }
 
-    private void waitOnMessages(String message, int size, IntSupplier sizeSupplier) {
+    private boolean waitOnSupplier(Supplier<Boolean> supplier) {
       // set to 5000ms because it seems reasonable
       long timeoutMs = 5000;
       long endTime = System.currentTimeMillis() + timeoutMs;
-      while (sizeSupplier.getAsInt() < size
-          && System.currentTimeMillis() < endTime) {
+      while (!supplier.get() && System.currentTimeMillis() < endTime) {
         synchronized (this) {
           long waitTime = endTime - System.currentTimeMillis();
           if (waitTime > 0) {
@@ -206,7 +202,12 @@ class BuildTargetServerIntegrationTest {
           }
         }
       }
-      assertEquals(size, sizeSupplier.getAsInt(), message + " count error");
+      return supplier.get();
+    }
+
+    private void waitOnMessages(String errorMessage, int size, IntSupplier sizeSupplier) {
+      waitOnSupplier(() -> sizeSupplier.getAsInt() >= size);
+      assertEquals(size, sizeSupplier.getAsInt(), errorMessage + " count error");
     }
 
     private CompileReport findCompileReport(BuildTargetIdentifier btId) {
@@ -331,24 +332,9 @@ class BuildTargetServerIntegrationTest {
       } catch (IOException e) {
         throw new IllegalStateException("Cannot setup streams", e);
       }
-      // server
-      BuildTargetManager buildTargetManager = new BuildTargetManager();
-      PreferenceManager preferenceManager = new PreferenceManager();
-      GradleApiConnector connector = new GradleApiConnector(preferenceManager);
-      LifecycleService lifecycleService = new LifecycleService(connector, preferenceManager);
-      BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
-          connector, preferenceManager);
-      GradleBuildServer gradleBuildServer = new GradleBuildServer(lifecycleService,
-          buildTargetService);
+      // server - set tracer param to `new PrintWriter(System.out)` for JSON message logging.
       org.eclipse.lsp4j.jsonrpc.Launcher<BuildClient> serverLauncher =
-          new org.eclipse.lsp4j.jsonrpc.Launcher.Builder<BuildClient>()
-          .setLocalService(gradleBuildServer)
-          .setRemoteInterface(BuildClient.class)
-          .setOutput(serverOut)
-          .setInput(serverIn)
-          .setExecutorService(threadPool)
-          .create();
-      buildTargetService.setClient(serverLauncher.getRemoteProxy());
+          Launcher.createLauncher(serverOut, serverIn, threadPool, null);
       // client
       TestClient client = new TestClient();
       org.eclipse.lsp4j.jsonrpc.Launcher<TestServer> clientLauncher =
@@ -369,7 +355,11 @@ class BuildTargetServerIntegrationTest {
         testServer.onBuildInitialized();
         consumer.accept(testServer, client);
       } finally {
-        testServer.buildShutdown().join();
+        try {
+          testServer.buildShutdown().get(10000, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+          // do nothing
+        }
         threadPool.shutdown();
       }
     } catch (IOException e) {
@@ -1848,7 +1838,6 @@ class BuildTargetServerIntegrationTest {
     });
   }
 
-
   @Test
   void testExtraConfiguration() {
     withNewTestServer("java-tests", (gradleBuildServer, client) -> {
@@ -1937,6 +1926,39 @@ class BuildTargetServerIntegrationTest {
           "extraTest()",
           List.of("extraTest()",
               "ExtraTests")));
+      client.clearMessages();
+    });
+  }
+  
+  /**
+   * This doesn't check that cancellation is successful as it may or may not be depending on timing.
+   */
+  @Test
+  void testCancellation() {
+    withNewTestServer("junit5-jupiter-starter-gradle", (gradleBuildServer, client) -> {
+      // get targets and request cancellation - can't test if it's cancelled as it may have 
+      // completed before cancel or because of cancel
+      gradleBuildServer.workspaceBuildTargets().cancel(false);
+      client.clearMessages();
+
+      // get targets again but don't cancel
+      WorkspaceBuildTargetsResult buildTargetsResult = gradleBuildServer.workspaceBuildTargets()
+          .join();
+      List<BuildTargetIdentifier> btIds = buildTargetsResult.getTargets().stream()
+          .map(BuildTarget::getId)
+          .collect(Collectors.toList());
+      client.clearMessages();
+
+      // clean targets
+      CleanCacheParams cleanCacheParams = new CleanCacheParams(btIds);
+      gradleBuildServer.buildTargetCleanCache(cleanCacheParams).join();
+      client.clearMessages();
+
+      // compile targets and request cancellation - can't test if it's cancelled as it may have 
+      // completed before cancel
+      CompileParams compileParams = new CompileParams(btIds);
+      compileParams.setOriginId("originId");
+      gradleBuildServer.buildTargetCompile(compileParams).cancel(false);
       client.clearMessages();
     });
   }

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -88,7 +88,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
         connector, preferenceManager);
 
-    WorkspaceBuildTargetsResult response = buildTargetService.getWorkspaceBuildTargets();
+    WorkspaceBuildTargetsResult response = buildTargetService.getWorkspaceBuildTargets(null);
 
     assertEquals(1, response.getTargets().size());
     assertEquals("foo/bar", response.getTargets().get(0).getBaseDirectory());
@@ -110,7 +110,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
             connector, preferenceManager);
 
-    WorkspaceBuildTargetsResult response = buildTargetService.getWorkspaceBuildTargets();
+    WorkspaceBuildTargetsResult response = buildTargetService.getWorkspaceBuildTargets(null);
 
     assertEquals(1, response.getTargets().size());
     assertEquals("foo/bar", response.getTargets().get(0).getBaseDirectory());
@@ -140,7 +140,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
         connector, preferenceManager);
     SourcesResult buildTargetSources = buildTargetService.getBuildTargetSources(new SourcesParams(
-            Arrays.asList(new BuildTargetIdentifier("test"))));
+            Arrays.asList(new BuildTargetIdentifier("test"))), null);
     buildTargetSources.getItems().forEach(item -> {
       item.getSources().forEach(sourceItem -> {
         if (sourceItem.getGenerated()) {
@@ -169,7 +169,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
         connector, preferenceManager);
     ResourcesResult buildTargetResources = buildTargetService.getBuildTargetResources(
-        new ResourcesParams(Arrays.asList(new BuildTargetIdentifier("test"))));
+        new ResourcesParams(Arrays.asList(new BuildTargetIdentifier("test"))), null);
     buildTargetResources.getItems().forEach(item -> {
       item.getResources().forEach(resource -> {
         assertTrue(resource.contains("resourceDir"));
@@ -195,7 +195,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
         connector, preferenceManager);
     OutputPathsResult  outputPathsResult = buildTargetService.getBuildTargetOutputPaths(
-        new OutputPathsParams(Arrays.asList(new BuildTargetIdentifier("test"))));
+        new OutputPathsParams(Arrays.asList(new BuildTargetIdentifier("test"))), null);
     assertEquals(1, outputPathsResult.getItems().size());
     assertEquals(2, outputPathsResult.getItems().get(0).getOutputPaths().size());
   }
@@ -214,7 +214,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
             connector, preferenceManager);
     DependencySourcesResult res = buildTargetService.getBuildTargetDependencySources(
-            new DependencySourcesParams(Arrays.asList(new BuildTargetIdentifier("test"))));
+            new DependencySourcesParams(Arrays.asList(new BuildTargetIdentifier("test"))), null);
     assertEquals(1, res.getItems().size());
 
     List<String> sources = res.getItems().get(0).getSources();
@@ -235,7 +235,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
         connector, preferenceManager);
     DependencyModulesResult res = buildTargetService.getBuildTargetDependencyModules(
-        new DependencyModulesParams(Arrays.asList(new BuildTargetIdentifier("test"))));
+        new DependencyModulesParams(Arrays.asList(new BuildTargetIdentifier("test"))), null);
     assertEquals(1, res.getItems().size());
 
     List<DependencyModule> modules = res.getItems().get(0).getModules();
@@ -310,7 +310,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
         connector, preferenceManager);
     JavacOptionsResult javacOptions = buildTargetService.getBuildTargetJavacOptions(
-        new JavacOptionsParams(Arrays.asList(new BuildTargetIdentifier("test"))));
+        new JavacOptionsParams(Arrays.asList(new BuildTargetIdentifier("test"))), null);
   
     assertEquals(1, javacOptions.getItems().size());
     assertEquals(2, javacOptions.getItems().get(0).getOptions().size());
@@ -340,7 +340,7 @@ class BuildTargetServiceTest {
     BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
             connector, preferenceManager);
     ScalacOptionsResult scalacOptions = buildTargetService.getBuildTargetScalacOptions(
-            new ScalacOptionsParams(Arrays.asList(new BuildTargetIdentifier("test"))));
+            new ScalacOptionsParams(Arrays.asList(new BuildTargetIdentifier("test"))), null);
 
     assertEquals(1, scalacOptions.getItems().size());
     assertEquals(4, scalacOptions.getItems().get(0).getOptions().size());

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/LifecycleServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/LifecycleServiceTest.java
@@ -43,10 +43,10 @@ class LifecycleServiceTest {
     );
 
     LifecycleService lifecycleService = mock(LifecycleService.class);
-    doNothing().when(lifecycleService).initializePreferenceManager(any());
-    when(lifecycleService.initializeServer(any())).thenCallRealMethod();
+    doNothing().when(lifecycleService).initializePreferenceManager(any(), any());
+    when(lifecycleService.initializeServer(any(), any())).thenCallRealMethod();
 
-    InitializeBuildResult res = lifecycleService.initializeServer(params);
+    InitializeBuildResult res = lifecycleService.initializeServer(params, null);
 
     assertEquals(Constants.SERVER_NAME, res.getDisplayName());
     assertEquals(Constants.SERVER_VERSION, res.getVersion());
@@ -71,7 +71,7 @@ class LifecycleServiceTest {
     PreferenceManager preferenceManager = new PreferenceManager();
     LifecycleService lifecycleService = new LifecycleService(
         mock(GradleApiConnector.class), preferenceManager);
-    lifecycleService.initializePreferenceManager(params);
+    lifecycleService.initializePreferenceManager(params, any());
 
     assertEquals("8.1", preferenceManager.getPreferences().getGradleVersion());
   }


### PR DESCRIPTION
This uses `org.gradle.tooling.CancellationToken` to tell any Gradle tasks running that they should cancel themselves when the BSP client cancels a request.

This is tricky to test because of timings - you could cancel a compilation request but it could already be complete by the time the cancel is triggered - so I've just put in an integ test that triggers cancels but doesn't check the outcome.

I've found the cancelling of chains of `CompletableFuture` is not that intuitive and I don't think it's necessary.
The `CompletableFuture` passed back to the BSP client is the only one that will be cancelled in the chain created in `GradleBuildServer#handleRequest`.
This will trigger `CancellationTokenSource#cancel` which should cause the Gradle task running to cancel itself.  The other parts of the chain should complete naturally and quickly (they're just small data transforms).

Looking at the BSP trace messages (I've added tracing to the screen as an option into the `Launcher`), the cancelled requests all return `null`.  I think this is fine as from a BSP client point of view the `CompletableFuture` has been cancelled and should have no result.

Continues work done by https://github.com/microsoft/build-server-for-gradle/pull/157