### PR TITLE
Handle java source/target defined at extension level

### DIFF
--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/JavaLanguageModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/JavaLanguageModelBuilder.java
@@ -20,6 +20,8 @@ import java.util.stream.Stream;
 import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
 import com.microsoft.java.bs.gradle.model.JavaExtension;
 import com.microsoft.java.bs.gradle.model.SupportedLanguage;
+import com.microsoft.java.bs.gradle.model.SupportedLanguages;
+import com.microsoft.java.bs.gradle.model.impl.DefaultJavaExtension;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -31,9 +33,6 @@ import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.plugins.ide.internal.tooling.java.DefaultInstalledJdk;
 import org.gradle.util.GradleVersion;
-
-import com.microsoft.java.bs.gradle.model.SupportedLanguages;
-import com.microsoft.java.bs.gradle.model.impl.DefaultJavaExtension;
 
 /**
  * The language model builder for Java language.
@@ -67,8 +66,10 @@ public class JavaLanguageModelBuilder extends LanguageModelBuilder {
 
       List<String> compilerArgs = getCompilerArgs(javaCompile);
       extension.setCompilerArgs(compilerArgs);
-      extension.setSourceCompatibility(getSourceCompatibility(compilerArgs));
-      extension.setTargetCompatibility(getTargetCompatibility(compilerArgs));
+      // Ignore options and get source/target compatibility directly from javaCompile.
+      extension.setSourceCompatibility(javaCompile.getSourceCompatibility());
+      extension.setTargetCompatibility(javaCompile.getTargetCompatibility());
+
       return extension;
     }
     return null;

--- a/testProjects/java-source-target/build.gradle
+++ b/testProjects/java-source-target/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+  id 'java'
+}
+
+java {
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_9
+}
+
+tasks.withType(JavaCompile) {
+  options.compilerArgs.addAll(['--release', '11'])
+}

--- a/testProjects/java-source-target/settings.gradle
+++ b/testProjects/java-source-target/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-source-target'


### PR DESCRIPTION
This will take into account the `java plugin` source/target compatibility settings.
e.g. using...
```
java {
  targetCompatibility = JavaVersion.VERSION_1_8
  sourceCompatibility = JavaVersion.VERSION_1_9
}
```
instead of
```
tasks.withType(JavaCompile) {
  sourceCompatibility = JavaVersion.VERSION_1_8
  targetCompatibility = JavaVersion.VERSION_1_9
}
```

I'm not sure if this is enough to fix https://github.com/redhat-developer/vscode-java/issues/3721.  The source/target compatibility in `JVMBuildTarget` will have changed but the javac options will still contain `--release 8`.  Hopefully that will be ok for the eclipse settings.

I note that [here](https://github.com/bsideup/jabel) it says to configure the `compileJava` task with source/target and not the `java` plugin when using `Jabel`

I've also extended the `POJO` constructor copying used in `DefaultSourceSets` to the language extensions.  It's not needed for normal running but it's a pain when debugging as all the variables/watches just show the proxy classes.