### PR TITLE
fix: use apache lang3 for stringUtils

### DIFF
--- a/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/gradle/Utils.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildActionExecuter;
 import org.gradle.tooling.BuildLauncher;


### PR DESCRIPTION
fix: use apache lang3 for stringUtils

This is fix to below error which cause java extension error:
!ENTRY org.eclipse.jdt.ls.core 4 0 2025-08-07 14:01:53.386
!MESSAGE Initialization failed
!STACK 0
java.util.concurrent.CompletionException: org.eclipse.lsp4j.jsonrpc.ResponseErrorException: org.gradle.internal.impldep.org.apache.commons.lang.StringUtils
	at java.base/java.util.concurrent.CompletableFuture.reportJoin(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.join(Unknown Source)
	at com.microsoft.gradle.bs.importer.Utils.getBuildTargetsMappedByProjectPath(Utils.java:55)
	at com.microsoft.gradle.bs.importer.GradleBuildServerProjectImporter.importProjects(GradleBuildServerProjectImporter.java:324)
	at com.microsoft.gradle.bs.importer.GradleBuildServerProjectImporter.importToWorkspace(GradleBuildServerProjectImporter.java:228)
	at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.importProjects(ProjectsManager.java:164)
	at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.initializeProjects(ProjectsManager.java:126)
	at org.eclipse.jdt.ls.core.internal.handlers.InitHandler$1.runInWorkspace(InitHandler.java:263)
	at org.eclipse.core.internal.resources.InternalWorkspaceJob.run(InternalWorkspaceJob.java:43)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
Caused by: org.eclipse.lsp4j.jsonrpc.ResponseErrorException: org.gradle.internal.impldep.org.apache.commons.lang.StringUtils
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleResponse(RemoteEndpoint.java:220)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:204)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:185)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:97)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:114)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)