### PR TITLE
Add jdk 25 support

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/JavaLanguageModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/JavaLanguageModelBuilder.java
@@ -86,11 +86,6 @@ public class JavaLanguageModelBuilder extends LanguageModelBuilder {
       if (generatedDir != null) {
         generatedSrcDirs.add(generatedDir.getAsFile());
       }
-    } else if (GradleVersion.current().compareTo(GradleVersion.version("4.3")) >= 0) {
-      File generatedDir = options.getAnnotationProcessorGeneratedSourcesDirectory();
-      if (generatedDir != null) {
-        generatedSrcDirs.add(generatedDir);
-      }
     }
   }
 
@@ -266,10 +261,6 @@ public class JavaLanguageModelBuilder extends LanguageModelBuilder {
   }
 
   private File getClassesDir(AbstractCompile compile) {
-    if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) >= 0) {
-      return compile.getDestinationDirectory().get().getAsFile();
-    } else {
-      return compile.getDestinationDir();
-    }
+    return compile.getDestinationDirectory().get().getAsFile();
   }
 }

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/ScalaLanguageModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/ScalaLanguageModelBuilder.java
@@ -177,11 +177,7 @@ public class ScalaLanguageModelBuilder extends LanguageModelBuilder {
 
   private File getClassesDir(AbstractCompile compile) {
     if (compile != null) {
-      if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) >= 0) {
-        return compile.getDestinationDirectory().get().getAsFile();
-      } else {
-        return compile.getDestinationDir();
-      }
+      return compile.getDestinationDirectory().get().getAsFile();
     }
 
     return null;

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -206,12 +206,7 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
       Set<Object> archiveSourcePaths = getArchiveSourcePaths(archiveTask.getRootSpec());
       for (Object sourcePath : archiveSourcePaths) {
         if (sourceSet.getOutput().equals(sourcePath)) {
-          File archiveFile;
-          if (GradleVersion.current().compareTo(GradleVersion.version("5.1")) >= 0) {
-            archiveFile = archiveTask.getArchiveFile().get().getAsFile();
-          } else {
-            archiveFile = archiveTask.getArchivePath();
-          }
+          File archiveFile = archiveTask.getArchiveFile().get().getAsFile();
           List<File> sourceSetOutputs = new LinkedList<>(sourceSet.getOutput().getFiles());
           archiveOutputFiles.put(archiveFile, sourceSetOutputs);
         }

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/dependency/DependencyCollector.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/dependency/DependencyCollector.java
@@ -50,37 +50,14 @@ public class DependencyCollector {
    */
   public static Set<GradleModuleDependency> getModuleDependencies(Project project,
       Set<String> configurationNames) {
-    if (GradleVersion.current().compareTo(GradleVersion.version("4.0")) < 0) {
-      try {
-        List<ResolvedConfiguration> configs = project.getConfigurations().stream()
-            .filter(configuration -> configurationNames.contains(configuration.getName()))
-              .map(Configuration::getResolvedConfiguration)
-            .collect(Collectors.toList());
-        Stream<DefaultGradleModuleDependency> dependencies = configs.stream()
-            .flatMap(config -> config.getResolvedArtifacts().stream())
-            .map(artifact -> getArtifact(project, artifact));
-
-        // add as individual files for direct dependencies on jars
-        Stream<DefaultGradleModuleDependency> directDependencies = configs.stream()
-            .flatMap(config -> config.getFiles(Specs.satisfyAll()).stream())
-            .map(DependencyCollector::getFileDependency);
-        return Stream.concat(dependencies, directDependencies)
-          .filter(Objects::nonNull)
-          .collect(Collectors.toSet());
-      } catch (GradleException ex) {
-        // handle build with unresolvable dependencies e.g. missing repository
-        return new HashSet<>();
-      }
-    } else {
-      return project.getConfigurations()
-        .stream()
-        .filter(configuration -> configurationNames.contains(configuration.getName()))
-        .filter(Configuration::isCanBeResolved)
-        .flatMap(configuration -> getConfigurationArtifacts(configuration).stream())
-        .map(artifactResult -> getArtifact(project, artifactResult))
-        .filter(Objects::nonNull)
-        .collect(Collectors.toSet());
-    }
+    return project.getConfigurations()
+      .stream()
+      .filter(configuration -> configurationNames.contains(configuration.getName()))
+      .filter(Configuration::isCanBeResolved)
+      .flatMap(configuration -> getConfigurationArtifacts(configuration).stream())
+      .map(artifactResult -> getArtifact(project, artifactResult))
+      .filter(Objects::nonNull)
+      .collect(Collectors.toSet());
   }
 
   private static DefaultGradleModuleDependency getArtifact(Project project,


### PR DESCRIPTION
Upgrade to Gradle 9.2.1 for JDK 25 support

Update build-server-for-gradle to be compatible with Gradle 9.2.1, which is required to support JDK 25.

Changes:
- Upgrade Gradle wrapper from 8.7 to 9.2.1
- Remove deprecated API calls for Gradle 9 compatibility:
  - Replace getArchivePath() with getArchiveFile().get().getAsFile()
  - Replace getDestinationDir() with getDestinationDirectory().get().getAsFile()
  - Replace getAnnotationProcessorGeneratedSourcesDirectory() with getGeneratedSourceOutputDirectory().getOrNull()
- Remove version checks for Gradle < 5.1, < 4.3, and < 6.1 as these are no longer needed when targeting Gradle 9.2.1+
- Simplify getModuleDependencies() to only use Gradle 4.0+ code path (removed legacy Gradle < 4.0 implementation that used removed APIs)

Breaking changes:
- Requires Gradle 9.2.1+ (minimum JDK 17)
- No longer supports Gradle versions < 4.0

Tested with Gradle 9.2.1 and JDK 25.