### PR TITLE
Upgrade guava to 32.0.1-jre and commons-lang3 to 3.18.0

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29,7 +29,7 @@
         "Maven": {
           "GroupId": "org.apache.commons",
           "ArtifactId": "commons-lang3",
-          "Version": "3.13.0"
+          "Version": "3.18.0"
         }
       },
       "DevelopmentDependency": false
@@ -84,7 +84,7 @@
         "Maven": {
           "GroupId": "com.google.guava",
           "ArtifactId": "guava",
-          "Version": "30.1-jre"
+          "Version": "32.0.1-jre"
         }
       },
       "DevelopmentDependency": false

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -5,7 +5,8 @@ plugins {
 dependencies {
     implementation project(':model')
     implementation 'ch.epfl.scala:bsp4j:2.1.0-M4'
-    implementation 'org.apache.commons:commons-lang3:3.13.0'
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
+    implementation 'com.google.guava:guava:32.0.1-jre'
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/server/src/main/resources/NOTICE.txt
+++ b/server/src/main/resources/NOTICE.txt
@@ -336,7 +336,7 @@ limitations under the License.
 
 ---------------------------------------------------------
 
-com.google.guava/guava 30.1-jre - Apache-2.0
+com.google.guava/guava 32.0.1-jre - Apache-2.0
 
 
 
@@ -1495,7 +1495,7 @@ ch.epfl.scala/bsp4j 2.1.0-M4 - Apache-2.0
 
 ---------------------------------------------------------
 
-org.apache.commons/commons-lang3 3.13.0 - Apache-2.0
+org.apache.commons/commons-lang3 3.18.0 - Apache-2.0
 
 Apache License
 Version 2.0, January 2004


### PR DESCRIPTION
Fix Dependabot security alerts by upgrading vulnerable dependencies:

## Changes

- **guava**: 30.1-jre → 32.0.1-jre
  - Fixes [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976) — `FileBackedOutputStream` uses insecure default temp directory
  - Fixes [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908) — `Files.createTempDir()` creates directory with insecure permissions
- **commons-lang3**: 3.13.0 → 3.18.0
  - Fixes [CVE-2025-46393](https://nvd.nist.gov/vuln/detail/CVE-2025-46393) — `ClassUtils.getClass()` uncontrolled recursion causing `StackOverflowError`

## Files modified

- `server/build.gradle` — Added explicit guava dependency, bumped commons-lang3 version
- `cgmanifest.json` — Updated registered component versions
- `server/src/main/resources/NOTICE.txt` — Updated version references