### PR TITLE
feat: expose BSP jvmTestEnvironment/jvmRunEnvironment

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
@@ -111,10 +111,11 @@ public interface GradleSourceSet extends Serializable {
   public List<File> getRuntimeClasspath();
 
   /**
-   * The JVM arguments configured on this source set's matching test task
-   * (e.g. {@code --add-opens} or {@code -D} system properties). Empty when the
-   * source set has no matching test task or no arguments were configured. This
-   * lets clients reproduce a faithful test JVM without re-deriving it.
+   * The effective JVM arguments needed to reproduce this source set's matching test
+   * task: its explicit {@code jvmArgs}, its {@code systemProperty} values (as
+   * {@code -Dkey=value}) and its heap settings ({@code -Xms}/{@code -Xmx}). Empty when
+   * the source set has no matching test task or nothing was configured. This lets
+   * clients launch a faithful test JVM without re-deriving it.
    */
   public List<String> getJvmArgs();
 

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
@@ -101,6 +101,14 @@ public interface GradleSourceSet extends Serializable {
   public List<File> getCompileClasspath();
 
   /**
+   * The JVM arguments configured on this source set's matching test task
+   * (e.g. {@code --add-opens} or {@code -D} system properties). Empty when the
+   * source set has no matching test task or no arguments were configured. This
+   * lets clients reproduce a faithful test JVM without re-deriving it.
+   */
+  public List<String> getJvmArgs();
+
+  /**
    * Module dependencies.
    */
   public Set<GradleModuleDependency> getModuleDependencies();

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/GradleSourceSet.java
@@ -101,6 +101,16 @@ public interface GradleSourceSet extends Serializable {
   public List<File> getCompileClasspath();
 
   /**
+   * The runtime classpath actually used to run this source set (for the test
+   * source set this mirrors the Gradle {@code Test} task's classpath: the source
+   * set's own output plus its runtime dependency closure). Unlike
+   * {@link #getCompileClasspath()} this includes {@code runtimeOnly} dependencies
+   * and excludes {@code compileOnly} ones, so clients can launch a faithful test
+   * or run JVM.
+   */
+  public List<File> getRuntimeClasspath();
+
+  /**
    * The JVM arguments configured on this source set's matching test task
    * (e.g. {@code --add-opens} or {@code -D} system properties). Empty when the
    * source set has no matching test task or no arguments were configured. This

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -55,6 +55,8 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   private List<File> compileClasspath;
 
+  private List<String> jvmArgs;
+
   private Set<GradleModuleDependency> moduleDependencies;
 
   private Set<BuildTargetDependency> buildTargetDependencies;
@@ -88,6 +90,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
     this.resourceOutputDirs = gradleSourceSet.getResourceOutputDirs();
     this.archiveOutputFiles = gradleSourceSet.getArchiveOutputFiles();
     this.compileClasspath = gradleSourceSet.getCompileClasspath();
+    this.jvmArgs = gradleSourceSet.getJvmArgs();
     this.moduleDependencies = gradleSourceSet.getModuleDependencies().stream()
         .map(DefaultGradleModuleDependency::new).collect(Collectors.toSet());
     this.buildTargetDependencies = gradleSourceSet.getBuildTargetDependencies().stream()
@@ -261,6 +264,15 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
   }
 
   @Override
+  public List<String> getJvmArgs() {
+    return jvmArgs;
+  }
+
+  public void setJvmArgs(List<String> jvmArgs) {
+    this.jvmArgs = jvmArgs;
+  }
+
+  @Override
   public Set<GradleModuleDependency> getModuleDependencies() {
     return moduleDependencies;
   }
@@ -302,7 +314,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         projectDir, rootDir, sourceSetName, classesTaskName, cleanTaskName, taskNames, sourceDirs,
         generatedSourceDirs, sourceOutputDirs, resourceDirs, resourceOutputDirs, archiveOutputFiles,
         compileClasspath, moduleDependencies, buildTargetDependencies,
-        hasTests, extensions);
+        hasTests, extensions, jvmArgs);
   }
 
   @Override
@@ -337,6 +349,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         && Objects.equals(moduleDependencies, other.moduleDependencies)
         && Objects.equals(buildTargetDependencies, other.buildTargetDependencies)
         && hasTests == other.hasTests
-        && Objects.equals(extensions, other.extensions);
+        && Objects.equals(extensions, other.extensions)
+        && Objects.equals(jvmArgs, other.jvmArgs);
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -55,6 +55,8 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   private List<File> compileClasspath;
 
+  private List<File> runtimeClasspath;
+
   private List<String> jvmArgs;
 
   private Set<GradleModuleDependency> moduleDependencies;
@@ -90,6 +92,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
     this.resourceOutputDirs = gradleSourceSet.getResourceOutputDirs();
     this.archiveOutputFiles = gradleSourceSet.getArchiveOutputFiles();
     this.compileClasspath = gradleSourceSet.getCompileClasspath();
+    this.runtimeClasspath = gradleSourceSet.getRuntimeClasspath();
     this.jvmArgs = gradleSourceSet.getJvmArgs();
     this.moduleDependencies = gradleSourceSet.getModuleDependencies().stream()
         .map(DefaultGradleModuleDependency::new).collect(Collectors.toSet());
@@ -264,6 +267,15 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
   }
 
   @Override
+  public List<File> getRuntimeClasspath() {
+    return runtimeClasspath;
+  }
+
+  public void setRuntimeClasspath(List<File> runtimeClasspath) {
+    this.runtimeClasspath = runtimeClasspath;
+  }
+
+  @Override
   public List<String> getJvmArgs() {
     return jvmArgs;
   }
@@ -313,7 +325,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
     return Objects.hash(gradleVersion, displayName, projectName, projectPath,
         projectDir, rootDir, sourceSetName, classesTaskName, cleanTaskName, taskNames, sourceDirs,
         generatedSourceDirs, sourceOutputDirs, resourceDirs, resourceOutputDirs, archiveOutputFiles,
-        compileClasspath, moduleDependencies, buildTargetDependencies,
+        compileClasspath, runtimeClasspath, moduleDependencies, buildTargetDependencies,
         hasTests, extensions, jvmArgs);
   }
 
@@ -346,6 +358,7 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
         && Objects.equals(resourceOutputDirs, other.resourceOutputDirs)
         && Objects.equals(archiveOutputFiles, other.archiveOutputFiles)
         && Objects.equals(compileClasspath, other.compileClasspath)
+        && Objects.equals(runtimeClasspath, other.runtimeClasspath)
         && Objects.equals(moduleDependencies, other.moduleDependencies)
         && Objects.equals(buildTargetDependencies, other.buildTargetDependencies)
         && hasTests == other.hasTests

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -4,6 +4,7 @@
 package com.microsoft.java.bs.gradle.model.impl;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -277,7 +278,9 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   @Override
   public List<String> getJvmArgs() {
-    return jvmArgs;
+    // Honour the interface contract: never null, even for a no-arg-constructed or
+    // deserialized instance whose field was not populated.
+    return jvmArgs == null ? new ArrayList<>() : jvmArgs;
   }
 
   public void setJvmArgs(List<String> jvmArgs) {

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/impl/DefaultGradleSourceSet.java
@@ -269,6 +269,12 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
 
   @Override
   public List<File> getRuntimeClasspath() {
+    // Honour the interface contract: never null, even for a no-arg-constructed or
+    // deserialized instance whose field was not populated. Assign back so the same
+    // list instance is returned on every call and mutations are not dropped.
+    if (runtimeClasspath == null) {
+      runtimeClasspath = new ArrayList<>();
+    }
     return runtimeClasspath;
   }
 
@@ -279,8 +285,12 @@ public class DefaultGradleSourceSet implements GradleSourceSet {
   @Override
   public List<String> getJvmArgs() {
     // Honour the interface contract: never null, even for a no-arg-constructed or
-    // deserialized instance whose field was not populated.
-    return jvmArgs == null ? new ArrayList<>() : jvmArgs;
+    // deserialized instance whose field was not populated. Assign back so the same
+    // list instance is returned on every call and mutations are not dropped.
+    if (jvmArgs == null) {
+      jvmArgs = new ArrayList<>();
+    }
+    return jvmArgs;
   }
 
   public void setJvmArgs(List<String> jvmArgs) {

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -129,6 +129,17 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
     }
     gradleSourceSet.setCompileClasspath(compileClasspath);
 
+    // runtime classpath - the closure Gradle actually uses to run this source set
+    // (includes runtimeOnly deps, excludes compileOnly). For the test source set a
+    // matching Test task below overrides this with the task's own classpath.
+    List<File> runtimeClasspath = new LinkedList<>();
+    try {
+      runtimeClasspath.addAll(sourceSet.getRuntimeClasspath().getFiles());
+    } catch (GradleException e) {
+      // ignore
+    }
+    gradleSourceSet.setRuntimeClasspath(runtimeClasspath);
+
     // resource
     Set<File> resourceDirs = sourceSet.getResources().getSrcDirs();
     gradleSourceSet.setResourceDirs(resourceDirs);
@@ -155,6 +166,10 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
             if (files.contains(sourceOutputDir)) {
               gradleSourceSet.setHasTests(true);
               gradleSourceSet.setJvmArgs(getTestJvmArgs(testTask));
+              List<File> testRuntimeClasspath = getTestRuntimeClasspath(testTask);
+              if (!testRuntimeClasspath.isEmpty()) {
+                gradleSourceSet.setRuntimeClasspath(testRuntimeClasspath);
+              }
               break;
             }
           }
@@ -169,6 +184,10 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
               if (sourceOutputDir.equals(testClassesDir)) {
                 gradleSourceSet.setHasTests(true);
                 gradleSourceSet.setJvmArgs(getTestJvmArgs(testTask));
+                List<File> testRuntimeClasspath = getTestRuntimeClasspath(testTask);
+                if (!testRuntimeClasspath.isEmpty()) {
+                  gradleSourceSet.setRuntimeClasspath(testRuntimeClasspath);
+                }
                 break;
               }
             }
@@ -194,6 +213,24 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
   private List<String> getTestJvmArgs(Test testTask) {
     List<String> jvmArgs = testTask.getJvmArgs();
     return jvmArgs == null ? new LinkedList<>() : new LinkedList<>(jvmArgs);
+  }
+
+  /**
+   * Collect the runtime classpath the Gradle {@code Test} task actually launches
+   * with ({@code test.classpath}), so clients reproduce the exact test JVM
+   * classpath instead of re-deriving it from compile/runtime configurations.
+   * Falls back to an empty list when the classpath cannot be resolved.
+   */
+  private List<File> getTestRuntimeClasspath(Test testTask) {
+    try {
+      FileCollection classpath = testTask.getClasspath();
+      if (classpath != null) {
+        return new LinkedList<>(classpath.getFiles());
+      }
+    } catch (GradleException e) {
+      // ignore - fall back to the source set's runtime classpath already set
+    }
+    return new LinkedList<>();
   }
 
   private <T extends Task> Set<T> tasksWithType(Project project, Class<T> clazz) {

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -154,6 +154,7 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
           for (File sourceOutputDir : sourceOutputDirs) {
             if (files.contains(sourceOutputDir)) {
               gradleSourceSet.setHasTests(true);
+              gradleSourceSet.setJvmArgs(getTestJvmArgs(testTask));
               break;
             }
           }
@@ -167,6 +168,7 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
             for (File sourceOutputDir : sourceOutputDirs) {
               if (sourceOutputDir.equals(testClassesDir)) {
                 gradleSourceSet.setHasTests(true);
+                gradleSourceSet.setJvmArgs(getTestJvmArgs(testTask));
                 break;
               }
             }
@@ -182,6 +184,16 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
     }
 
     return gradleSourceSet;
+  }
+
+  /**
+   * Collect the JVM arguments configured on a test task (e.g. {@code --add-opens}
+   * or {@code -D} system properties) so clients can reproduce a faithful test JVM.
+   * Returns an empty list when none are configured.
+   */
+  private List<String> getTestJvmArgs(Test testTask) {
+    List<String> jvmArgs = testTask.getJvmArgs();
+    return jvmArgs == null ? new LinkedList<>() : new LinkedList<>(jvmArgs);
   }
 
   private <T extends Task> Set<T> tasksWithType(Project project, Class<T> clazz) {

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -140,6 +140,11 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
     }
     gradleSourceSet.setRuntimeClasspath(runtimeClasspath);
 
+    // Default to an empty list so getJvmArgs() honours its "empty, never null"
+    // contract for source sets without a matching test task; the test loop below
+    // overrides this when a Test task is found.
+    gradleSourceSet.setJvmArgs(new LinkedList<>());
+
     // resource
     Set<File> resourceDirs = sourceSet.getResources().getSrcDirs();
     gradleSourceSet.setResourceDirs(resourceDirs);

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -206,13 +206,43 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
   }
 
   /**
-   * Collect the JVM arguments configured on a test task (e.g. {@code --add-opens}
-   * or {@code -D} system properties) so clients can reproduce a faithful test JVM.
-   * Returns an empty list when none are configured.
+   * Collect the effective JVM arguments a client needs to reproduce the test JVM.
+   *
+   * <p>{@link Test#getJvmArgs()} only returns arguments set explicitly via
+   * {@code jvmArgs(...)}; it omits {@code systemProperty(...)} values (managed
+   * separately by {@link Test#getSystemProperties()}) and the heap settings
+   * ({@code minHeapSize}/{@code maxHeapSize}). We merge those in as
+   * {@code -Dkey=value}, {@code -Xms} and {@code -Xmx} so a very common
+   * {@code systemProperty(...)} configuration is not silently dropped (which could
+   * change test behaviour or make tests fail under a delegated coverage run). We
+   * avoid {@link Test#getAllJvmArgs()} because it is deprecated since Gradle 8.</p>
+   *
+   * <p>Note: {@code jvmArgumentProviders} are not captured here; that API is newer
+   * than the oldest Gradle versions this plugin still supports.</p>
+   *
+   * <p>Returns an empty list when nothing is configured.</p>
    */
   private List<String> getTestJvmArgs(Test testTask) {
+    List<String> args = new LinkedList<>();
     List<String> jvmArgs = testTask.getJvmArgs();
-    return jvmArgs == null ? new LinkedList<>() : new LinkedList<>(jvmArgs);
+    if (jvmArgs != null) {
+      args.addAll(jvmArgs);
+    }
+    Map<String, Object> sysProps = testTask.getSystemProperties();
+    if (sysProps != null) {
+      for (Map.Entry<String, Object> e : sysProps.entrySet()) {
+        args.add("-D" + e.getKey() + "=" + e.getValue());
+      }
+    }
+    String min = testTask.getMinHeapSize();
+    if (min != null) {
+      args.add("-Xms" + min);
+    }
+    String max = testTask.getMaxHeapSize();
+    if (max != null) {
+      args.add("-Xmx" + max);
+    }
+    return args;
   }
 
   /**

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -14,6 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import com.microsoft.java.bs.gradle.plugin.utils.AndroidUtils;
@@ -235,8 +236,11 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
     }
     Map<String, Object> sysProps = testTask.getSystemProperties();
     if (sysProps != null) {
-      for (Map.Entry<String, Object> e : sysProps.entrySet()) {
-        args.add("-D" + e.getKey() + "=" + e.getValue());
+      // Sort by key for a deterministic order (getSystemProperties() may be a
+      // HashMap), so the serialized model and BSP response stay stable across runs.
+      for (Map.Entry<String, Object> e : new TreeMap<>(sysProps).entrySet()) {
+        Object value = e.getValue();
+        args.add("-D" + e.getKey() + "=" + (value == null ? "" : value));
       }
     }
     String min = testTask.getMinHeapSize();

--- a/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
+++ b/plugin/src/main/java/com/microsoft/java/bs/gradle/plugin/SourceSetsModelBuilder.java
@@ -135,7 +135,12 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
     // matching Test task below overrides this with the task's own classpath.
     List<File> runtimeClasspath = new LinkedList<>();
     try {
-      runtimeClasspath.addAll(sourceSet.getRuntimeClasspath().getFiles());
+      // Iterate the FileCollection directly rather than via getFiles() (which returns
+      // a Set) to preserve Gradle's classpath ordering; order affects which
+      // classes/resources win on the runtime classpath.
+      for (File file : sourceSet.getRuntimeClasspath()) {
+        runtimeClasspath.add(file);
+      }
     } catch (GradleException e) {
       // ignore
     }
@@ -261,15 +266,20 @@ public class SourceSetsModelBuilder implements ToolingModelBuilder {
    * Falls back to an empty list when the classpath cannot be resolved.
    */
   private List<File> getTestRuntimeClasspath(Test testTask) {
+    List<File> classpathFiles = new LinkedList<>();
     try {
       FileCollection classpath = testTask.getClasspath();
       if (classpath != null) {
-        return new LinkedList<>(classpath.getFiles());
+        // Iterate the FileCollection directly rather than via getFiles() (which
+        // returns a Set) to preserve Gradle's classpath ordering.
+        for (File file : classpath) {
+          classpathFiles.add(file);
+        }
       }
     } catch (GradleException e) {
       // ignore - fall back to the source set's runtime classpath already set
     }
-    return new LinkedList<>();
+    return classpathFiles;
   }
 
   private <T extends Task> Set<T> tasksWithType(Project project, Class<T> clazz) {

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/server/GradleBuildServer.java
@@ -41,6 +41,11 @@ import ch.epfl.scala.bsp4j.InverseSourcesResult;
 import ch.epfl.scala.bsp4j.JavaBuildServer;
 import ch.epfl.scala.bsp4j.JavacOptionsParams;
 import ch.epfl.scala.bsp4j.JavacOptionsResult;
+import ch.epfl.scala.bsp4j.JvmBuildServer;
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
 import ch.epfl.scala.bsp4j.OutputPathsParams;
 import ch.epfl.scala.bsp4j.OutputPathsResult;
 import ch.epfl.scala.bsp4j.ResourcesParams;
@@ -63,7 +68,8 @@ import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 /**
  * The implementation of the Build Server Protocol.
  */
-public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBuildServer {
+public class GradleBuildServer implements BuildServer, JavaBuildServer, JvmBuildServer,
+    ScalaBuildServer {
 
   private LifecycleService lifecycleService;
 
@@ -201,6 +207,20 @@ public class GradleBuildServer implements BuildServer, JavaBuildServer, ScalaBui
       ScalaMainClassesParams params) {
     // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unimplemented method 'buildTargetScalaMainClasses'");
+  }
+
+  @Override
+  public CompletableFuture<JvmTestEnvironmentResult> jvmTestEnvironment(
+      JvmTestEnvironmentParams params) {
+    return handleRequest("buildTarget/jvmTestEnvironment", cc ->
+        buildTargetService.getBuildTargetJvmTestEnvironment(params));
+  }
+
+  @Override
+  public CompletableFuture<JvmRunEnvironmentResult> jvmRunEnvironment(
+      JvmRunEnvironmentParams params) {
+    return handleRequest("buildTarget/jvmRunEnvironment", cc ->
+        buildTargetService.getBuildTargetJvmRunEnvironment(params));
   }
 
   private void handleNotification(String methodName, Runnable runnable, boolean async) {

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -491,6 +491,15 @@ public class BuildTargetService {
    * {@code Test} task's actual classpath, so {@code runtimeOnly} dependencies are
    * included and {@code compileOnly} ones are excluded).
    *
+   * <p><b>Android limitation:</b> Android build variants (produced by
+   * {@code AndroidUtils}) do not populate {@code runtimeClasspath} or {@code jvmArgs} on
+   * the source set. For such targets the returned classpath is therefore limited to the
+   * source set's output directories (runtime dependencies are missing) and
+   * {@code jvmOptions} is empty. This is currently acceptable because the VS Code Gradle
+   * client excludes Android projects from the build-server import path, so this endpoint
+   * is not exercised for them; populating a faithful Android test/run environment would
+   * require {@code AndroidUtils} to model the variant's runtime classpath and JVM args.</p>
+   *
    * @param isTestEnvironment when {@code true} the matching Gradle {@code Test} task's
    *     JVM arguments are surfaced as {@code jvmOptions}; for a run environment they are
    *     omitted because they are test-specific.

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -29,6 +29,7 @@ import com.microsoft.java.bs.core.internal.reporter.ProgressReporter;
 import com.microsoft.java.bs.core.internal.utils.JsonUtils;
 import com.microsoft.java.bs.core.internal.utils.TelemetryUtils;
 import com.microsoft.java.bs.core.internal.utils.UriUtils;
+import com.microsoft.java.bs.gradle.model.Artifact;
 import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
@@ -483,8 +484,11 @@ public class BuildTargetService {
 
   /**
    * Build a {@link JvmEnvironmentItem} for each resolvable build target. The classpath
-   * is composed of the source set compile classpath plus its own compiled output and
-   * resource directories, so that the target's own classes are runnable/testable.
+   * mirrors the test/run runtime: the source set's own compiled output and resource
+   * directories, its compile classpath, and its module dependency artifacts (which are
+   * resolved from both the compile and runtime configurations, so runtime-only
+   * dependencies are included). JVM options are taken from the matching Gradle test
+   * task where available.
    */
   private List<JvmEnvironmentItem> collectJvmEnvironmentItems(List<BuildTargetIdentifier> targets) {
     List<JvmEnvironmentItem> items = new ArrayList<>();
@@ -497,22 +501,43 @@ public class BuildTargetService {
       }
 
       GradleSourceSet sourceSet = target.getSourceSet();
-      Set<File> classpathEntries = new LinkedHashSet<>();
-      classpathEntries.addAll(sourceSet.getSourceOutputDirs());
-      classpathEntries.addAll(sourceSet.getResourceOutputDirs());
-      classpathEntries.addAll(sourceSet.getCompileClasspath());
-      List<String> classpath = classpathEntries.stream()
-          .map(file -> file.toURI().toString())
-          .collect(Collectors.toList());
+      // Use a LinkedHashSet so the classpath keeps a stable order and duplicates
+      // (e.g. a compile-classpath entry that is also a module artifact) collapse.
+      Set<String> classpath = new LinkedHashSet<>();
+      for (File dir : sourceSet.getSourceOutputDirs()) {
+        classpath.add(dir.toURI().toString());
+      }
+      for (File dir : sourceSet.getResourceOutputDirs()) {
+        classpath.add(dir.toURI().toString());
+      }
+      for (File file : sourceSet.getCompileClasspath()) {
+        classpath.add(file.toURI().toString());
+      }
+      // Add module dependency artifacts to pick up runtime-only dependencies that
+      // are absent from the compile classpath. Skip sources/javadoc classifiers.
+      for (GradleModuleDependency dep : sourceSet.getModuleDependencies()) {
+        for (Artifact artifact : dep.getArtifacts()) {
+          String classifier = artifact.getClassifier();
+          if (!"sources".equals(classifier) && !"javadoc".equals(classifier)) {
+            classpath.add(artifact.getUri().toString());
+          }
+        }
+      }
 
       File projectDir = sourceSet.getProjectDir();
       String workingDirectory = projectDir == null ? "" : projectDir.toURI().toString();
 
+      List<String> jvmArgs = sourceSet.getJvmArgs();
+      List<String> jvmOptions = jvmArgs == null ? new ArrayList<>() : new ArrayList<>(jvmArgs);
+
       items.add(new JvmEnvironmentItem(
           btId,
-          classpath,
-          new ArrayList<>(),
+          new ArrayList<>(classpath),
+          jvmOptions,
           workingDirectory,
+          // Environment variables are intentionally left empty: the Gradle test
+          // task's effective environment inherits the whole machine environment,
+          // which is noisy and host-specific, so we do not surface it here.
           new HashMap<>()
       ));
     }

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -521,15 +521,15 @@ public class BuildTargetService {
       Set<String> classpath = new LinkedHashSet<>();
       Set<File> sourceOutputDirs = sourceSet.getSourceOutputDirs();
       if (sourceOutputDirs != null) {
-        for (File dir : sourceOutputDirs) {
-          classpath.add(dir.toURI().toString());
-        }
+        // Sort for a deterministic classpath order (the model builder stores these
+        // as an unordered HashSet).
+        sourceOutputDirs.stream().sorted()
+            .forEach(dir -> classpath.add(dir.toURI().toString()));
       }
       Set<File> resourceOutputDirs = sourceSet.getResourceOutputDirs();
       if (resourceOutputDirs != null) {
-        for (File dir : resourceOutputDirs) {
-          classpath.add(dir.toURI().toString());
-        }
+        resourceOutputDirs.stream().sorted()
+            .forEach(dir -> classpath.add(dir.toURI().toString()));
       }
       // Use the runtime classpath Gradle actually launches the test/run JVM with,
       // rather than the compile classpath: this includes runtime-only dependencies

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,6 +54,11 @@ import ch.epfl.scala.bsp4j.DependencySourcesResult;
 import ch.epfl.scala.bsp4j.JavacOptionsItem;
 import ch.epfl.scala.bsp4j.JavacOptionsParams;
 import ch.epfl.scala.bsp4j.JavacOptionsResult;
+import ch.epfl.scala.bsp4j.JvmEnvironmentItem;
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
 import ch.epfl.scala.bsp4j.DidChangeBuildTarget;
 import ch.epfl.scala.bsp4j.MavenDependencyModule;
 import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
@@ -449,7 +455,70 @@ public class BuildTargetService {
     }
     return new JavacOptionsResult(items);
   }
-  
+
+  /**
+   * Get the JVM test environment (classpath, JVM options, working directory and
+   * environment variables) for the requested build targets.
+   *
+   * <p>Implements the BSP standard {@code buildTarget/jvmTestEnvironment} request so
+   * clients (e.g. the VS Code Gradle extension) can reproduce a faithful test
+   * runtime - which is required to run tests with the same classpath the Gradle
+   * build uses, and to layer on capabilities such as code coverage.</p>
+   */
+  public JvmTestEnvironmentResult getBuildTargetJvmTestEnvironment(
+      JvmTestEnvironmentParams params) {
+    return new JvmTestEnvironmentResult(collectJvmEnvironmentItems(params.getTargets()));
+  }
+
+  /**
+   * Get the JVM run environment for the requested build targets.
+   *
+   * <p>Implements the BSP standard {@code buildTarget/jvmRunEnvironment} request. It
+   * currently mirrors {@link #getBuildTargetJvmTestEnvironment} since the Gradle model
+   * exposes the same classpath/output information for both cases.</p>
+   */
+  public JvmRunEnvironmentResult getBuildTargetJvmRunEnvironment(JvmRunEnvironmentParams params) {
+    return new JvmRunEnvironmentResult(collectJvmEnvironmentItems(params.getTargets()));
+  }
+
+  /**
+   * Build a {@link JvmEnvironmentItem} for each resolvable build target. The classpath
+   * is composed of the source set compile classpath plus its own compiled output and
+   * resource directories, so that the target's own classes are runnable/testable.
+   */
+  private List<JvmEnvironmentItem> collectJvmEnvironmentItems(List<BuildTargetIdentifier> targets) {
+    List<JvmEnvironmentItem> items = new ArrayList<>();
+    for (BuildTargetIdentifier btId : targets) {
+      GradleBuildTarget target = getGradleBuildTarget(btId);
+      if (target == null) {
+        LOGGER.warning("Skip JVM environment collection for the build target: " + btId.getUri()
+            + ". Because it cannot be found in the cache.");
+        continue;
+      }
+
+      GradleSourceSet sourceSet = target.getSourceSet();
+      Set<File> classpathEntries = new LinkedHashSet<>();
+      classpathEntries.addAll(sourceSet.getSourceOutputDirs());
+      classpathEntries.addAll(sourceSet.getResourceOutputDirs());
+      classpathEntries.addAll(sourceSet.getCompileClasspath());
+      List<String> classpath = classpathEntries.stream()
+          .map(file -> file.toURI().toString())
+          .collect(Collectors.toList());
+
+      File projectDir = sourceSet.getProjectDir();
+      String workingDirectory = projectDir == null ? "" : projectDir.toURI().toString();
+
+      items.add(new JvmEnvironmentItem(
+          btId,
+          classpath,
+          new ArrayList<>(),
+          workingDirectory,
+          new HashMap<>()
+      ));
+    }
+    return items;
+  }
+
   /**
    * Get the Scala compiler options.
    */

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -29,7 +29,6 @@ import com.microsoft.java.bs.core.internal.reporter.ProgressReporter;
 import com.microsoft.java.bs.core.internal.utils.JsonUtils;
 import com.microsoft.java.bs.core.internal.utils.TelemetryUtils;
 import com.microsoft.java.bs.core.internal.utils.UriUtils;
-import com.microsoft.java.bs.gradle.model.Artifact;
 import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
@@ -485,10 +484,10 @@ public class BuildTargetService {
   /**
    * Build a {@link JvmEnvironmentItem} for each resolvable build target. The classpath
    * mirrors the test/run runtime: the source set's own compiled output and resource
-   * directories, its compile classpath, and its module dependency artifacts (which are
-   * resolved from both the compile and runtime configurations, so runtime-only
-   * dependencies are included). JVM options are taken from the matching Gradle test
-   * task where available.
+   * directories plus its runtime classpath (for the test source set this is the Gradle
+   * {@code Test} task's actual classpath, so {@code runtimeOnly} dependencies are
+   * included and {@code compileOnly} ones are excluded). JVM options are taken from the
+   * matching Gradle test task where available.
    */
   private List<JvmEnvironmentItem> collectJvmEnvironmentItems(List<BuildTargetIdentifier> targets) {
     List<JvmEnvironmentItem> items = new ArrayList<>();
@@ -502,7 +501,7 @@ public class BuildTargetService {
 
       GradleSourceSet sourceSet = target.getSourceSet();
       // Use a LinkedHashSet so the classpath keeps a stable order and duplicates
-      // (e.g. a compile-classpath entry that is also a module artifact) collapse.
+      // (e.g. an output dir that is also on the runtime classpath) collapse.
       Set<String> classpath = new LinkedHashSet<>();
       for (File dir : sourceSet.getSourceOutputDirs()) {
         classpath.add(dir.toURI().toString());
@@ -510,17 +509,13 @@ public class BuildTargetService {
       for (File dir : sourceSet.getResourceOutputDirs()) {
         classpath.add(dir.toURI().toString());
       }
-      for (File file : sourceSet.getCompileClasspath()) {
-        classpath.add(file.toURI().toString());
-      }
-      // Add module dependency artifacts to pick up runtime-only dependencies that
-      // are absent from the compile classpath. Skip sources/javadoc classifiers.
-      for (GradleModuleDependency dep : sourceSet.getModuleDependencies()) {
-        for (Artifact artifact : dep.getArtifacts()) {
-          String classifier = artifact.getClassifier();
-          if (!"sources".equals(classifier) && !"javadoc".equals(classifier)) {
-            classpath.add(artifact.getUri().toString());
-          }
+      // Use the runtime classpath Gradle actually launches the test/run JVM with,
+      // rather than the compile classpath: this includes runtime-only dependencies
+      // and excludes compile-only ones.
+      List<File> runtimeClasspath = sourceSet.getRuntimeClasspath();
+      if (runtimeClasspath != null) {
+        for (File file : runtimeClasspath) {
+          classpath.add(file.toURI().toString());
         }
       }
 

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -527,7 +527,12 @@ public class BuildTargetService {
       }
 
       File projectDir = sourceSet.getProjectDir();
-      String workingDirectory = projectDir == null ? "" : projectDir.toURI().toString();
+      // Use a plain filesystem path (not a file:// URI) for the working directory.
+      // Unlike classpath entries, BSP's workingDirectory is consumed as the directory
+      // to launch the process in, and its format is inconsistent across build tools
+      // (e.g. Bloop uses a plain path); a plain path is directly usable as a process
+      // working directory, whereas a file:// URI is not.
+      String workingDirectory = projectDir == null ? "" : projectDir.getAbsolutePath();
 
       // Only a test environment surfaces the Gradle Test task's JVM args; a run
       // environment must not inherit test-specific options such as --add-opens.

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -467,18 +467,21 @@ public class BuildTargetService {
    */
   public JvmTestEnvironmentResult getBuildTargetJvmTestEnvironment(
       JvmTestEnvironmentParams params) {
-    return new JvmTestEnvironmentResult(collectJvmEnvironmentItems(params.getTargets()));
+    return new JvmTestEnvironmentResult(collectJvmEnvironmentItems(params.getTargets(), true));
   }
 
   /**
    * Get the JVM run environment for the requested build targets.
    *
    * <p>Implements the BSP standard {@code buildTarget/jvmRunEnvironment} request. It
-   * currently mirrors {@link #getBuildTargetJvmTestEnvironment} since the Gradle model
-   * exposes the same classpath/output information for both cases.</p>
+   * shares the classpath/output/working-directory collection with
+   * {@link #getBuildTargetJvmTestEnvironment} but deliberately does <em>not</em> carry
+   * the matching {@code Test} task's JVM arguments (e.g. {@code --add-opens}): those are
+   * test-specific and have no meaning for a run environment. Run/application JVM args and
+   * {@code mainClasses} are not modelled yet, so {@code jvmOptions} is left empty.</p>
    */
   public JvmRunEnvironmentResult getBuildTargetJvmRunEnvironment(JvmRunEnvironmentParams params) {
-    return new JvmRunEnvironmentResult(collectJvmEnvironmentItems(params.getTargets()));
+    return new JvmRunEnvironmentResult(collectJvmEnvironmentItems(params.getTargets(), false));
   }
 
   /**
@@ -486,10 +489,14 @@ public class BuildTargetService {
    * mirrors the test/run runtime: the source set's own compiled output and resource
    * directories plus its runtime classpath (for the test source set this is the Gradle
    * {@code Test} task's actual classpath, so {@code runtimeOnly} dependencies are
-   * included and {@code compileOnly} ones are excluded). JVM options are taken from the
-   * matching Gradle test task where available.
+   * included and {@code compileOnly} ones are excluded).
+   *
+   * @param isTestEnvironment when {@code true} the matching Gradle {@code Test} task's
+   *     JVM arguments are surfaced as {@code jvmOptions}; for a run environment they are
+   *     omitted because they are test-specific.
    */
-  private List<JvmEnvironmentItem> collectJvmEnvironmentItems(List<BuildTargetIdentifier> targets) {
+  private List<JvmEnvironmentItem> collectJvmEnvironmentItems(List<BuildTargetIdentifier> targets,
+      boolean isTestEnvironment) {
     List<JvmEnvironmentItem> items = new ArrayList<>();
     for (BuildTargetIdentifier btId : targets) {
       GradleBuildTarget target = getGradleBuildTarget(btId);
@@ -522,8 +529,15 @@ public class BuildTargetService {
       File projectDir = sourceSet.getProjectDir();
       String workingDirectory = projectDir == null ? "" : projectDir.toURI().toString();
 
-      List<String> jvmArgs = sourceSet.getJvmArgs();
-      List<String> jvmOptions = jvmArgs == null ? new ArrayList<>() : new ArrayList<>(jvmArgs);
+      // Only a test environment surfaces the Gradle Test task's JVM args; a run
+      // environment must not inherit test-specific options such as --add-opens.
+      List<String> jvmOptions = new ArrayList<>();
+      if (isTestEnvironment) {
+        List<String> jvmArgs = sourceSet.getJvmArgs();
+        if (jvmArgs != null) {
+          jvmOptions.addAll(jvmArgs);
+        }
+      }
 
       items.add(new JvmEnvironmentItem(
           btId,

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -510,11 +510,17 @@ public class BuildTargetService {
       // Use a LinkedHashSet so the classpath keeps a stable order and duplicates
       // (e.g. an output dir that is also on the runtime classpath) collapse.
       Set<String> classpath = new LinkedHashSet<>();
-      for (File dir : sourceSet.getSourceOutputDirs()) {
-        classpath.add(dir.toURI().toString());
+      Set<File> sourceOutputDirs = sourceSet.getSourceOutputDirs();
+      if (sourceOutputDirs != null) {
+        for (File dir : sourceOutputDirs) {
+          classpath.add(dir.toURI().toString());
+        }
       }
-      for (File dir : sourceSet.getResourceOutputDirs()) {
-        classpath.add(dir.toURI().toString());
+      Set<File> resourceOutputDirs = sourceSet.getResourceOutputDirs();
+      if (resourceOutputDirs != null) {
+        for (File dir : resourceOutputDirs) {
+          classpath.add(dir.toURI().toString());
+        }
       }
       // Use the runtime classpath Gradle actually launches the test/run JVM with,
       // rather than the compile classpath: this includes runtime-only dependencies

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/LifecycleService.java
@@ -101,6 +101,8 @@ public class LifecycleService {
     capabilities.setCanReload(true);
     capabilities.setBuildTargetChangedProvider(true);
     capabilities.setCompileProvider(new CompileProvider(SupportedLanguages.allBspNames));
+    capabilities.setJvmRunEnvironmentProvider(true);
+    capabilities.setJvmTestEnvironmentProvider(true);
     return capabilities;
   }
 

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -306,9 +306,10 @@ class BuildTargetServiceTest {
         .thenReturn(new HashSet<>(Arrays.asList(new File("out/classes"))));
     when(gradleSourceSet.getResourceOutputDirs())
         .thenReturn(new HashSet<>(Arrays.asList(new File("out/resources"))));
-    when(gradleSourceSet.getCompileClasspath())
-        .thenReturn(Arrays.asList(new File("libs/compile.jar")));
-    when(gradleSourceSet.getModuleDependencies()).thenReturn(getRuntimeModuleDependencies());
+    // Runtime classpath = the Gradle Test task's actual classpath: it carries the
+    // runtime-only artifact but not the compile-only one.
+    when(gradleSourceSet.getRuntimeClasspath())
+        .thenReturn(Arrays.asList(new File("libs/runtime.jar"), new File("out/classes")));
     when(gradleSourceSet.getJvmArgs())
         .thenReturn(Arrays.asList("--add-opens=java.base/java.lang=ALL-UNNAMED"));
 
@@ -324,65 +325,15 @@ class BuildTargetServiceTest {
     assertEquals(Arrays.asList("--add-opens=java.base/java.lang=ALL-UNNAMED"),
         item.getJvmOptions());
 
-    // The classpath includes outputs, the compile classpath and the runtime
-    // (non-sources) module artifact, but not the sources artifact.
+    // The classpath includes the outputs and the runtime classpath entries, but not
+    // a compile-only jar that is absent from the runtime classpath.
     List<String> classpath = item.getClasspath();
     assertTrue(classpath.contains(new File("out/classes").toURI().toString()));
     assertTrue(classpath.contains(new File("out/resources").toURI().toString()));
-    assertTrue(classpath.contains(new File("libs/compile.jar").toURI().toString()));
-    assertTrue(classpath.contains(new File("runtime.jar").toURI().toString()));
-    assertFalse(classpath.contains(new File("sources.jar").toURI().toString()));
+    assertTrue(classpath.contains(new File("libs/runtime.jar").toURI().toString()));
+    assertFalse(classpath.contains(new File("libs/compileOnly.jar").toURI().toString()));
 
     assertEquals(new File("projectDir").toURI().toString(), item.getWorkingDirectory());
-  }
-
-  private static Set<GradleModuleDependency> getRuntimeModuleDependencies() {
-    GradleModuleDependency moduleDependency = new GradleModuleDependency() {
-      @Override
-      public String getGroup() {
-        return "group";
-      }
-
-      @Override
-      public String getModule() {
-        return "module";
-      }
-
-      @Override
-      public String getVersion() {
-        return "1.0.0";
-      }
-
-      @Override
-      public List<Artifact> getArtifacts() {
-        return Arrays.asList(
-            new Artifact() {
-              @Override
-              public URI getUri() {
-                return new File("runtime.jar").toURI();
-              }
-
-              @Override
-              public String getClassifier() {
-                return null;
-              }
-            },
-            new Artifact() {
-              @Override
-              public URI getUri() {
-                return new File("sources.jar").toURI();
-              }
-
-              @Override
-              public String getClassifier() {
-                return "sources";
-              }
-            });
-      }
-    };
-    Set<GradleModuleDependency> moduleDependencies = new HashSet<>();
-    moduleDependencies.add(moduleDependency);
-    return moduleDependencies;
   }
 
   @Test

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -4,6 +4,7 @@
 package com.microsoft.java.bs.core.internal.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,6 +50,9 @@ import ch.epfl.scala.bsp4j.DependencyModulesParams;
 import ch.epfl.scala.bsp4j.DependencyModulesResult;
 import ch.epfl.scala.bsp4j.JavacOptionsParams;
 import ch.epfl.scala.bsp4j.JavacOptionsResult;
+import ch.epfl.scala.bsp4j.JvmEnvironmentItem;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
 import ch.epfl.scala.bsp4j.MavenDependencyModule;
 import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
 import ch.epfl.scala.bsp4j.OutputPathsParams;
@@ -283,6 +287,97 @@ class BuildTargetServiceTest {
             return "sources";
           }
         });
+      }
+    };
+    Set<GradleModuleDependency> moduleDependencies = new HashSet<>();
+    moduleDependencies.add(moduleDependency);
+    return moduleDependencies;
+  }
+
+  @Test
+  void testGetBuildTargetJvmTestEnvironment() {
+    GradleBuildTarget gradleBuildTarget = mock(GradleBuildTarget.class);
+    when(buildTargetManager.getGradleBuildTarget(any())).thenReturn(gradleBuildTarget);
+
+    GradleSourceSet gradleSourceSet = mock(GradleSourceSet.class);
+    when(gradleBuildTarget.getSourceSet()).thenReturn(gradleSourceSet);
+    when(gradleSourceSet.getProjectDir()).thenReturn(new File("projectDir"));
+    when(gradleSourceSet.getSourceOutputDirs())
+        .thenReturn(new HashSet<>(Arrays.asList(new File("out/classes"))));
+    when(gradleSourceSet.getResourceOutputDirs())
+        .thenReturn(new HashSet<>(Arrays.asList(new File("out/resources"))));
+    when(gradleSourceSet.getCompileClasspath())
+        .thenReturn(Arrays.asList(new File("libs/compile.jar")));
+    when(gradleSourceSet.getModuleDependencies()).thenReturn(getRuntimeModuleDependencies());
+    when(gradleSourceSet.getJvmArgs())
+        .thenReturn(Arrays.asList("--add-opens=java.base/java.lang=ALL-UNNAMED"));
+
+    BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
+        connector, preferenceManager);
+    JvmTestEnvironmentResult res = buildTargetService.getBuildTargetJvmTestEnvironment(
+        new JvmTestEnvironmentParams(Arrays.asList(new BuildTargetIdentifier("test"))));
+
+    assertEquals(1, res.getItems().size());
+    JvmEnvironmentItem item = res.getItems().get(0);
+
+    // The test task's JVM args are surfaced as jvmOptions.
+    assertEquals(Arrays.asList("--add-opens=java.base/java.lang=ALL-UNNAMED"),
+        item.getJvmOptions());
+
+    // The classpath includes outputs, the compile classpath and the runtime
+    // (non-sources) module artifact, but not the sources artifact.
+    List<String> classpath = item.getClasspath();
+    assertTrue(classpath.contains(new File("out/classes").toURI().toString()));
+    assertTrue(classpath.contains(new File("out/resources").toURI().toString()));
+    assertTrue(classpath.contains(new File("libs/compile.jar").toURI().toString()));
+    assertTrue(classpath.contains(new File("runtime.jar").toURI().toString()));
+    assertFalse(classpath.contains(new File("sources.jar").toURI().toString()));
+
+    assertEquals(new File("projectDir").toURI().toString(), item.getWorkingDirectory());
+  }
+
+  private static Set<GradleModuleDependency> getRuntimeModuleDependencies() {
+    GradleModuleDependency moduleDependency = new GradleModuleDependency() {
+      @Override
+      public String getGroup() {
+        return "group";
+      }
+
+      @Override
+      public String getModule() {
+        return "module";
+      }
+
+      @Override
+      public String getVersion() {
+        return "1.0.0";
+      }
+
+      @Override
+      public List<Artifact> getArtifacts() {
+        return Arrays.asList(
+            new Artifact() {
+              @Override
+              public URI getUri() {
+                return new File("runtime.jar").toURI();
+              }
+
+              @Override
+              public String getClassifier() {
+                return null;
+              }
+            },
+            new Artifact() {
+              @Override
+              public URI getUri() {
+                return new File("sources.jar").toURI();
+              }
+
+              @Override
+              public String getClassifier() {
+                return "sources";
+              }
+            });
       }
     };
     Set<GradleModuleDependency> moduleDependencies = new HashSet<>();

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -51,6 +51,8 @@ import ch.epfl.scala.bsp4j.DependencyModulesResult;
 import ch.epfl.scala.bsp4j.JavacOptionsParams;
 import ch.epfl.scala.bsp4j.JavacOptionsResult;
 import ch.epfl.scala.bsp4j.JvmEnvironmentItem;
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams;
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult;
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams;
 import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult;
 import ch.epfl.scala.bsp4j.MavenDependencyModule;
@@ -334,6 +336,37 @@ class BuildTargetServiceTest {
     assertFalse(classpath.contains(new File("libs/compileOnly.jar").toURI().toString()));
 
     assertEquals(new File("projectDir").toURI().toString(), item.getWorkingDirectory());
+  }
+
+  @Test
+  void testGetBuildTargetJvmRunEnvironment() {
+    GradleBuildTarget gradleBuildTarget = mock(GradleBuildTarget.class);
+    when(buildTargetManager.getGradleBuildTarget(any())).thenReturn(gradleBuildTarget);
+
+    GradleSourceSet gradleSourceSet = mock(GradleSourceSet.class);
+    when(gradleBuildTarget.getSourceSet()).thenReturn(gradleSourceSet);
+    when(gradleSourceSet.getProjectDir()).thenReturn(new File("projectDir"));
+    when(gradleSourceSet.getSourceOutputDirs())
+        .thenReturn(new HashSet<>(Arrays.asList(new File("out/classes"))));
+    when(gradleSourceSet.getRuntimeClasspath())
+        .thenReturn(Arrays.asList(new File("libs/runtime.jar")));
+    // Even when the source set carries test JVM args, the run environment must not
+    // surface them - they are test-specific.
+    when(gradleSourceSet.getJvmArgs())
+        .thenReturn(Arrays.asList("--add-opens=java.base/java.lang=ALL-UNNAMED"));
+
+    BuildTargetService buildTargetService = new BuildTargetService(buildTargetManager,
+        connector, preferenceManager);
+    JvmRunEnvironmentResult res = buildTargetService.getBuildTargetJvmRunEnvironment(
+        new JvmRunEnvironmentParams(Arrays.asList(new BuildTargetIdentifier("test"))));
+
+    assertEquals(1, res.getItems().size());
+    JvmEnvironmentItem item = res.getItems().get(0);
+
+    // No test JVM args leak into the run environment.
+    assertTrue(item.getJvmOptions().isEmpty());
+    // The runtime classpath is still provided.
+    assertTrue(item.getClasspath().contains(new File("libs/runtime.jar").toURI().toString()));
   }
 
   @Test

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -335,7 +335,7 @@ class BuildTargetServiceTest {
     assertTrue(classpath.contains(new File("libs/runtime.jar").toURI().toString()));
     assertFalse(classpath.contains(new File("libs/compileOnly.jar").toURI().toString()));
 
-    assertEquals(new File("projectDir").toURI().toString(), item.getWorkingDirectory());
+    assertEquals(new File("projectDir").getAbsolutePath(), item.getWorkingDirectory());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements the two BSP-standard JVM environment requests — `buildTarget/jvmTestEnvironment` and `buildTarget/jvmRunEnvironment` — and advertises the matching `jvmTestEnvironmentProvider` / `jvmRunEnvironmentProvider` capabilities.

This lets a client query a faithful JVM **test** runtime for a build target (runtime classpath, JVM options, working directory, environment), which the VS Code Gradle extension needs to raise "Delegate Test to Gradle" to a default-level experience — notably code coverage.

> Cross-repo dependency for the P0 of microsoft/vscode-gradle#1890.

## What changed

### Server (`server`)

- **`LifecycleService`** — advertise `jvmTestEnvironmentProvider` and `jvmRunEnvironmentProvider` in the server capabilities.
- **`GradleBuildServer`** — implement `JvmBuildServer` (`jvmTestEnvironment`, `jvmRunEnvironment`), dispatching through the existing `handleRequest` plumbing.
- **`BuildTargetService`** — `collectJvmEnvironmentItems(targets, isTestEnvironment)` builds one `JvmEnvironmentItem` per resolvable target:
  - **classpath** = the source set's own output/resource dirs **plus its runtime classpath** — the closure Gradle actually launches with, so `runtimeOnly` dependencies are included and `compileOnly` ones excluded. Output dirs are sorted and the whole set de-duplicated for a stable, deterministic order.
  - **jvmOptions** = the source set's test JVM args, **only for the test environment**. The run environment deliberately omits them, so test-specific flags (e.g. `--add-opens`) don't leak into a run JVM.
  - **workingDirectory** = the project directory as a **plain filesystem path** (not a `file://` URI): BSP consumes it as a process working directory, and the format is inconsistent across build tools (e.g. Bloop uses a plain path).
  - **environment** = intentionally empty — `Test.getEnvironment()` returns the full inherited machine environment, which is noisy, host-specific and leaky.

### Model (`model`)

- **`GradleSourceSet`** — add `getRuntimeClasspath()` and `getJvmArgs()` (both documented as never-null). `DefaultGradleSourceSet` gets the backing fields, getters/setters, copy-constructor and `equals`/`hashCode` entries; `getJvmArgs()` returns an empty list rather than `null` for no-arg-constructed or deserialized instances.

### Plugin (`plugin`)

- **`SourceSetsModelBuilder`** — capture each source set's runtime classpath, overriding it with the matching `Test` task's actual classpath (`test.classpath`) when one is found. `getTestJvmArgs(...)` collects the effective test JVM args:
  - explicit `jvmArgs(...)`;
  - `systemProperty(...)` values rendered as `-Dkey=value` (Gradle manages these separately from `getJvmArgs()`, so they would otherwise be silently dropped; sorted by key for a deterministic order);
  - heap settings as `-Xms` / `-Xmx`.

  These are merged explicitly rather than via `Test.getAllJvmArgs()`, which is deprecated since Gradle 8.

## Testing

- `./gradlew :model:compileJava :plugin:compileJava :server:compileJava` — passes
- `./gradlew :model:checkstyleMain :plugin:checkstyleMain :server:checkstyleMain :server:checkstyleTest` — passes
- `./gradlew :server:test --tests BuildTargetServiceTest` — passes; asserts the test environment classpath uses the **runtime** classpath (`runtimeOnly` included, `compileOnly` excluded), a plain-path working directory, and that the **run** environment does **not** surface test JVM args.

## Known limitations / follow-ups

- **`mainClasses`** for the run environment is not populated yet (not required by the current test-environment use case).
- **`jvmArgumentProviders`** are not captured — that API is newer than the oldest Gradle versions this plugin still supports, so calling it unconditionally would risk `NoSuchMethodError`.
- **Android:** Android build variants (from `AndroidUtils`) do not populate `runtimeClasspath` / `jvmArgs`, so for those targets the classpath is limited to output dirs and `jvmOptions` is empty. Acceptable today because the VS Code Gradle client excludes Android from the build-server import path; a faithful Android environment would require `AndroidUtils` to model the variant's runtime classpath and JVM args. Documented on `collectJvmEnvironmentItems`.
- No end-to-end integration test with a fixture project yet (unit-level coverage is added in `BuildTargetServiceTest`).
