### PR TITLE
Use URIBuilder for output path query parameters

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':model')
     implementation 'ch.epfl.scala:bsp4j:2.1.0-M4'
     implementation 'org.apache.commons:commons-lang3:3.18.0'
+    implementation 'org.apache.httpcomponents.core5:httpcore5:5.3.4'
     implementation 'com.google.guava:guava:32.0.1-jre'
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))

--- a/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
+++ b/server/src/main/java/com/microsoft/java/bs/core/internal/services/BuildTargetService.java
@@ -7,6 +7,7 @@ import static com.microsoft.java.bs.core.Launcher.LOGGER;
 
 import java.io.File;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,6 +83,7 @@ import ch.epfl.scala.bsp4j.TestParamsDataKind;
 import ch.epfl.scala.bsp4j.TestResult;
 import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.core5.net.URIBuilder;
 
 /**
  * Service to handle build target related BSP requests.
@@ -247,7 +249,7 @@ public class BuildTargetService {
       if (sourceOutputDirs != null) {
         for (File sourceOutputDir : sourceOutputDirs) {
           outputPaths.add(new OutputPathItem(
-              sourceOutputDir.toURI() + "?kind=source",
+              toOutputPathUri(sourceOutputDir, "source"),
               OutputPathItemKind.DIRECTORY
           ));
         }
@@ -257,7 +259,7 @@ public class BuildTargetService {
       if (resourceOutputDirs != null) {
         for (File resourceOutputDir : resourceOutputDirs) {
           outputPaths.add(new OutputPathItem(
-              resourceOutputDir.toURI() + "?kind=resource",
+              toOutputPathUri(resourceOutputDir, "resource"),
               OutputPathItemKind.DIRECTORY
           ));
         }
@@ -267,6 +269,17 @@ public class BuildTargetService {
       items.add(item);
     }
     return new OutputPathsResult(items);
+  }
+
+  private String toOutputPathUri(File outputDir, String kind) {
+    try {
+      return new URIBuilder(outputDir.toURI())
+          .setParameter("kind", kind)
+          .build()
+          .toString();
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Failed to build output path URI for " + outputDir, e);
+    }
   }
 
   /**

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/services/BuildTargetServiceTest.java
@@ -51,6 +51,7 @@ import ch.epfl.scala.bsp4j.JavacOptionsParams;
 import ch.epfl.scala.bsp4j.JavacOptionsResult;
 import ch.epfl.scala.bsp4j.MavenDependencyModule;
 import ch.epfl.scala.bsp4j.MavenDependencyModuleArtifact;
+import ch.epfl.scala.bsp4j.OutputPathItem;
 import ch.epfl.scala.bsp4j.OutputPathsParams;
 import ch.epfl.scala.bsp4j.OutputPathsResult;
 import ch.epfl.scala.bsp4j.ResourcesParams;
@@ -200,6 +201,19 @@ class BuildTargetServiceTest {
         new OutputPathsParams(Arrays.asList(new BuildTargetIdentifier("test"))));
     assertEquals(1, outputPathsResult.getItems().size());
     assertEquals(2, outputPathsResult.getItems().get(0).getOutputPaths().size());
+
+    Map<String, URI> outputPathUris = new HashMap<>();
+    for (OutputPathItem outputPath : outputPathsResult.getItems().get(0).getOutputPaths()) {
+      URI uri = URI.create(outputPath.getUri());
+      outputPathUris.put(uri.getQuery(), uri);
+    }
+
+    assertTrue(outputPathUris.containsKey("kind=source"));
+    assertTrue(outputPathUris.containsKey("kind=resource"));
+    assertEquals(sourceOutputDir.toURI().getPath(),
+        outputPathUris.get("kind=source").getPath());
+    assertEquals(resourceOutputDir.toURI().getPath(),
+        outputPathUris.get("kind=resource").getPath());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Replace manual `?kind=...` concatenation for output path URIs with `URIBuilder#setParameter`.
- Add Apache HttpComponents Core 5 for `URIBuilder`.
- Extend `BuildTargetServiceTest` to assert source/resource query parameters and paths.

Closes #52

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH="/opt/homebrew/opt/openjdk@17/bin:$PATH" ./gradlew :server:test --tests com.microsoft.java.bs.core.internal.services.BuildTargetServiceTest`
