### PR TITLE
build: resolve Gradle dependencies through the Central Feed Service

### DIFF
--- a/.azure-pipelines/cfs-init.gradle
+++ b/.azure-pipelines/cfs-init.gradle
@@ -1,0 +1,83 @@
+/*
+ * Gradle settings for the build pipelines in this directory. SFI Network Isolation
+ * requires builds to resolve artifacts through the Central Feed Service (CFS) instead
+ * of reaching a public host, and this file is how that is applied.
+ *
+ * It is an init script rather than an edit to build.gradle on purpose. Gradle has no
+ * mirror concept, so redirecting `mavenCentral()` means replacing the repository list,
+ * and doing that in build.gradle would point every external contributor at a feed they
+ * cannot authenticate against. Passing this file through --init-script keeps the change
+ * confined to the agents: anyone running ./gradlew locally never applies it and keeps
+ * resolving from Maven Central exactly as before.
+ *
+ * repositoriesMode is PREFER_SETTINGS, which makes Gradle ignore the repositories
+ * declared in build.gradle in favour of the ones below. Prepending the feed instead
+ * would leave Maven Central as a fallback, so a single artifact missing from CFS would
+ * quietly reach the public host and reintroduce the violation this file exists to fix.
+ *
+ * Neither of the values read below is a secret in this file. Both arrive from the
+ * environment and are only set on the agents; see gradle-cfs-variables.yml for the
+ * non-secret half and the `env:` block on the Gradle task for the credential.
+ */
+
+def cfsUrl = System.getenv('CFS_MAVEN_URL')
+def cfsToken = System.getenv('SYSTEM_ACCESSTOKEN')
+
+if (!cfsUrl?.trim() || !cfsToken?.trim()) {
+    throw new GradleException(
+        'CFS_MAVEN_URL and SYSTEM_ACCESSTOKEN must both be set when cfs-init.gradle is applied. ' +
+        'Failing here rather than resolving from a public repository, which is the outcome ' +
+        'this script exists to prevent.')
+}
+
+// gradle-tooling-api is published only to repo.gradle.org. It is absent from Maven
+// Central and 404s through the feed, and Azure Artifacts upstreams cannot point at an
+// arbitrary URL, so it has to stay reachable directly. The content filter keeps that
+// exception to the one group that needs it -- everything else must come from CFS.
+def toolingApiUrl = 'https://repo.gradle.org/gradle/libs-releases'
+
+def addCfsRepository = { handler ->
+    handler.maven { repo ->
+        repo.name = 'vscjava'
+        repo.setUrl(cfsUrl)
+        repo.credentials { credentials ->
+            credentials.username = 'AzureDevOps'
+            credentials.password = cfsToken
+        }
+    }
+}
+
+def addToolingApiRepository = { handler ->
+    handler.maven { repo ->
+        repo.name = 'gradleLibsReleases'
+        repo.setUrl(toolingApiUrl)
+        repo.content { content ->
+            content.includeGroup('org.gradle')
+        }
+    }
+}
+
+beforeSettings { settings ->
+    settings.pluginManagement { pluginManagement ->
+        pluginManagement.repositories { handler ->
+            handler.clear()
+            addCfsRepository(handler)
+        }
+    }
+
+    settings.dependencyResolutionManagement { management ->
+        management.repositoriesMode.set(org.gradle.api.initialization.resolve.RepositoriesMode.PREFER_SETTINGS)
+        management.repositories { handler ->
+            handler.clear()
+            addCfsRepository(handler)
+            addToolingApiRepository(handler)
+        }
+    }
+}
+
+allprojects { project ->
+    project.buildscript.repositories { handler ->
+        handler.clear()
+        addCfsRepository(handler)
+    }
+}

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -12,6 +12,8 @@ trigger:
   branches:
     include:
       - develop
+variables:
+  - template: /.azure-pipelines/gradle-cfs-variables.yml@self
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
@@ -50,7 +52,14 @@ extends:
               - task: Gradle@3
                 displayName: gradlew build
                 inputs:
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   publishJUnitResults: false
+                # System.AccessToken is a secret, and Azure Pipelines does not export secret
+                # variables to the environment -- not even through a variable that merely
+                # references one. It is mapped here, on the step that actually runs Gradle,
+                # rather than in gradle-cfs-variables.yml alongside the rest of the wiring.
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               - task: CopyFiles@2
                 displayName: Copy jars
                 inputs:

--- a/.azure-pipelines/gradle-cfs-variables.yml
+++ b/.azure-pipelines/gradle-cfs-variables.yml
@@ -1,0 +1,20 @@
+# Non-secret half of the Central Feed Service (CFS) wiring for Gradle builds.
+#
+# SFI Network Isolation requires builds to resolve artifacts through CFS instead of
+# reaching a public host. The redirect itself lives in cfs-init.gradle, which is applied
+# to the Gradle tasks below through --init-script; this file only supplies the feed
+# address it reads.
+#
+# The credential is deliberately absent. System.AccessToken is a secret, and Azure
+# Pipelines does not export secret variables to the environment -- not even through a
+# variable that merely references one -- so it has to be mapped in an `env:` block on
+# the step that actually runs Gradle. Keeping it there also limits the token to the one
+# step that needs it instead of the whole job.
+#
+# Nothing here is secret: the value is a feed address, and it is only consumed on the
+# build agents. A developer running ./gradlew locally never applies cfs-init.gradle and
+# keeps resolving from Maven Central.
+
+variables:
+  - name: CFS_MAVEN_URL
+    value: https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/maven/v1

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -9,6 +9,8 @@ resources:
       name: 1ESPipelineTemplates/MicroBuildTemplate
 trigger: none
 pr: none
+variables:
+  - template: /.azure-pipelines/gradle-cfs-variables.yml@self
 schedules:
   - cron: '0 1 * * 1-5'
     displayName: 'Weekday 9AM Shanghai (1AM UTC)'
@@ -63,8 +65,14 @@ extends:
               - task: Gradle@3
                 displayName: gradlew build -x test
                 inputs:
-                  options: '-x test'
+                  options: '-x test --init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   publishJUnitResults: false
+                # System.AccessToken is a secret, and Azure Pipelines does not export secret
+                # variables to the environment -- not even through a variable that merely
+                # references one. It is mapped here, on the step that actually runs Gradle,
+                # rather than in gradle-cfs-variables.yml alongside the rest of the wiring.
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               - task: PowerShell@2
                 displayName: Sign Plugin Jars
                 inputs:


### PR DESCRIPTION
SFI Network Isolation (MountainPass SR21, ICM 840100965) requires build pipelines to stop reaching public package hosts. Pipeline **16493** (`microsoft.build-server-for-gradle-1es-rc`) is flagged for `CFSClean` with **486** requests to `repo.maven.apache.org` in the last 30 days, all coming from the `mavenCentral()` declaration in `build.gradle`.

## Why an init script instead of editing `build.gradle`

Gradle has no mirror concept, so redirecting `mavenCentral()` means replacing the repository list. Doing that in `build.gradle` would point every external contributor at a feed they cannot authenticate against.

The redirect therefore lives in `.azure-pipelines/cfs-init.gradle`, applied only on the agents via `--init-script`. **`build.gradle`, `settings.gradle` and the wrapper are untouched** — anyone running `./gradlew` locally keeps resolving from Maven Central exactly as before.

## Why `PREFER_SETTINGS` rather than prepending the feed

Prepending CFS would leave Maven Central as a fallback, so a single artifact missing from the feed would quietly reach the public host and reintroduce the violation this change exists to fix. `repositoriesMode = PREFER_SETTINGS` makes Gradle ignore the project-declared repositories outright.

Proven by pointing `CFS_MAVEN_URL` at a non-existent feed:

```
> Could not find org.slf4j:slf4j-api:2.0.17.

repo.maven.apache.org      0
repo1.maven.org            0
search.maven.org           0
oss.sonatype.org           0
```

It fails rather than falling through.

## The one exception: `gradle-tooling-api`

`org.gradle:gradle-tooling-api:9.2.0` is published only to `repo.gradle.org` — 404 on Maven Central *and* 404 through the feed — and Azure Artifacts upstreams cannot point at an arbitrary URL. That repository stays, narrowed by a content filter to the `org.gradle` group so nothing else can leak through it.

This does not block the exit criteria: on this pipeline `repo.gradle.org` and `services.gradle.org` only trigger `DefaultDeny`, which is not counted, and `CFSClean2` / `CFSClean3` have **zero violations in the last 90 days**.

## Where the token lives

Nowhere in the repo. `gradle-cfs-variables.yml` holds only the feed address. The credential is `System.AccessToken`, mapped in an `env:` block on the Gradle step — `System.AccessToken` is a secret and Azure Pipelines does not export secret variables to the environment, not even through a variable that merely references one. Scoping it to the step also keeps it out of every other task in the job.

## Verification

Local build against a clean `GRADLE_USER_HOME`:

```
BUILD SUCCESSFUL in 2m 26s

pkgs.dev.azure.com       131
repo.maven.apache.org      0
repo1.maven.org            0
search.maven.org           0
oss.sonatype.org           0
plugins.gradle.org         0
repo.gradle.org            3   <- gradle-tooling-api .pom/.jar/.module only
```

Fail-closed check with the variables unset:

```
> CFS_MAVEN_URL and SYSTEM_ACCESSTOKEN must both be set when cfs-init.gradle is applied.
```

`POST /_apis/pipelines/16493/preview` compiles against this branch, with the `env:` block and `--init-script` present in the final YAML.

## Note on `ci.yml`

Pipeline 16492 is currently **disabled** and not in the SR21 scope, but the same wiring is applied for consistency. One gap remains there if it is ever re-enabled: `gradlew build` runs tests, which spawn the builds under `testProjects/` through the tooling API as separate Gradle invocations that this init script does not reach. Those declare their own `mavenCentral()`. Out of scope here.
