### PR TITLE
fix: exclude build target outputs from module dependencies

### DIFF
--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/actions/GetSourceSetsAction.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/actions/GetSourceSetsAction.java
@@ -4,9 +4,11 @@
 package com.microsoft.java.bs.gradle.model.actions;
 
 import com.microsoft.java.bs.gradle.model.BuildTargetDependency;
+import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
 import com.microsoft.java.bs.gradle.model.GradleSourceSet;
 import com.microsoft.java.bs.gradle.model.GradleSourceSets;
 import com.microsoft.java.bs.gradle.model.impl.DefaultBuildTargetDependency;
+import com.microsoft.java.bs.gradle.model.impl.DefaultGradleModuleDependency;
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSet;
 import com.microsoft.java.bs.gradle.model.impl.DefaultGradleSourceSets;
 import org.gradle.tooling.BuildAction;
@@ -15,6 +17,7 @@ import org.gradle.tooling.model.gradle.BasicGradleProject;
 import org.gradle.tooling.model.gradle.GradleBuild;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -158,12 +161,14 @@ public class GetSourceSetsAction implements BuildAction<GradleSourceSets> {
     // replace classpath entries that reference jars with classes dirs.
     for (GradleSourceSet sourceSet : sourceSets) {
       Set<BuildTargetDependency> dependencies = new HashSet<>();
+      Set<URI> dependencyOutputUris = new HashSet<>();
       List<File> classpath = new ArrayList<>();
       for (File file : sourceSet.getCompileClasspath()) {
         // add project dependency
         GradleSourceSet otherSourceSet = outputsToSourceSet.get(file);
         if (otherSourceSet != null) {
           dependencies.add(new DefaultBuildTargetDependency(otherSourceSet));
+          dependencyOutputUris.add(file.toURI());
         }
         // replace jar on classpath with source output on classpath
         List<File> sourceOutputDir = archivesToSourceOutput.get(file);
@@ -176,7 +181,25 @@ public class GetSourceSetsAction implements BuildAction<GradleSourceSets> {
       if (sourceSet instanceof DefaultGradleSourceSet) {
         ((DefaultGradleSourceSet) sourceSet).setBuildTargetDependencies(dependencies);
         ((DefaultGradleSourceSet) sourceSet).setCompileClasspath(classpath);
+        ((DefaultGradleSourceSet) sourceSet).setModuleDependencies(
+            removeBuildTargetArtifacts(sourceSet.getModuleDependencies(), dependencyOutputUris));
       }
     }
+  }
+
+  private Set<GradleModuleDependency> removeBuildTargetArtifacts(
+      Set<GradleModuleDependency> moduleDependencies, Set<URI> dependencyOutputUris) {
+    Set<GradleModuleDependency> filteredDependencies = new HashSet<>();
+    for (GradleModuleDependency moduleDependency : moduleDependencies) {
+      DefaultGradleModuleDependency filteredDependency =
+          new DefaultGradleModuleDependency(moduleDependency);
+      filteredDependency.setArtifacts(filteredDependency.getArtifacts().stream()
+          .filter(artifact -> !dependencyOutputUris.contains(artifact.getUri()))
+          .collect(Collectors.toList()));
+      if (!filteredDependency.getArtifacts().isEmpty()) {
+        filteredDependencies.add(filteredDependency);
+      }
+    }
+    return filteredDependencies;
   }
 }

--- a/model/src/main/java/com/microsoft/java/bs/gradle/model/actions/GetSourceSetsAction.java
+++ b/model/src/main/java/com/microsoft/java/bs/gradle/model/actions/GetSourceSetsAction.java
@@ -168,7 +168,7 @@ public class GetSourceSetsAction implements BuildAction<GradleSourceSets> {
         GradleSourceSet otherSourceSet = outputsToSourceSet.get(file);
         if (otherSourceSet != null) {
           dependencies.add(new DefaultBuildTargetDependency(otherSourceSet));
-          dependencyOutputUris.add(file.toURI());
+          addOutputUris(dependencyOutputUris, otherSourceSet);
         }
         // replace jar on classpath with source output on classpath
         List<File> sourceOutputDir = archivesToSourceOutput.get(file);
@@ -187,7 +187,21 @@ public class GetSourceSetsAction implements BuildAction<GradleSourceSets> {
     }
   }
 
-  private Set<GradleModuleDependency> removeBuildTargetArtifacts(
+  private void addOutputUris(Set<URI> outputUris, GradleSourceSet sourceSet) {
+    if (sourceSet.getSourceOutputDirs() != null) {
+      sourceSet.getSourceOutputDirs().stream().map(File::toURI).forEach(outputUris::add);
+    }
+    if (sourceSet.getResourceOutputDirs() != null) {
+      sourceSet.getResourceOutputDirs().stream().map(File::toURI).forEach(outputUris::add);
+    }
+    if (sourceSet.getArchiveOutputFiles() != null) {
+      sourceSet.getArchiveOutputFiles().keySet().stream()
+          .map(File::toURI)
+          .forEach(outputUris::add);
+    }
+  }
+
+  static Set<GradleModuleDependency> removeBuildTargetArtifacts(
       Set<GradleModuleDependency> moduleDependencies, Set<URI> dependencyOutputUris) {
     Set<GradleModuleDependency> filteredDependencies = new HashSet<>();
     for (GradleModuleDependency moduleDependency : moduleDependencies) {

--- a/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/core/internal/gradle/GradleApiConnectorTest.java
@@ -217,6 +217,18 @@ class GradleApiConnectorTest {
     });
   }
 
+  private void assertNoModuleDependencyOnBuildTargetOutput(GradleSourceSet sourceSet,
+      GradleSourceSet dependency) {
+    Set<File> outputs = new HashSet<>();
+    outputs.addAll(dependency.getSourceOutputDirs());
+    outputs.addAll(dependency.getResourceOutputDirs());
+    outputs.addAll(dependency.getArchiveOutputFiles().keySet());
+    assertTrue(sourceSet.getModuleDependencies().stream()
+        .flatMap(module -> module.getArtifacts().stream())
+        .noneMatch(artifact -> outputs.contains(new File(artifact.getUri()))),
+        "Build target outputs must not also be exposed as module dependencies");
+  }
+
   @Test
   void testGetGradleDependenciesWithTestFixtures() {
     File projectDir = projectPath.resolve("project-dependency-test-fixtures").toFile();
@@ -277,6 +289,7 @@ class GradleApiConnectorTest {
     GradleSourceSet mainA = findSourceSet(gradleSourceSets, "a [main]");
     GradleSourceSet mainB = findSourceSet(gradleSourceSets, "b [main]");
     assertHasBuildTargetDependency(mainB, mainA);
+    assertNoModuleDependencyOnBuildTargetOutput(mainB, mainA);
   }
 
   @Test

--- a/server/src/test/java/com/microsoft/java/bs/gradle/model/actions/GetSourceSetsActionTest.java
+++ b/server/src/test/java/com/microsoft/java/bs/gradle/model/actions/GetSourceSetsActionTest.java
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.java.bs.gradle.model.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import com.microsoft.java.bs.gradle.model.GradleModuleDependency;
+import com.microsoft.java.bs.gradle.model.impl.DefaultArtifact;
+import com.microsoft.java.bs.gradle.model.impl.DefaultGradleModuleDependency;
+import org.junit.jupiter.api.Test;
+
+class GetSourceSetsActionTest {
+
+  @Test
+  void testRemoveBuildTargetArtifactsPreservesOtherArtifacts() {
+    URI buildTargetOutput = new File("project-a/build/classes/java/main").toURI();
+    URI externalArtifact = new File("repository/external.jar").toURI();
+    DefaultGradleModuleDependency dependency = new DefaultGradleModuleDependency(
+        "group",
+        "module",
+        "1.0.0",
+        Arrays.asList(
+            new DefaultArtifact(buildTargetOutput, null),
+            new DefaultArtifact(externalArtifact, null)));
+
+    Set<GradleModuleDependency> filteredDependencies =
+        GetSourceSetsAction.removeBuildTargetArtifacts(
+            Collections.singleton(dependency),
+            Collections.singleton(buildTargetOutput));
+
+    assertEquals(1, filteredDependencies.size());
+    GradleModuleDependency filteredDependency = filteredDependencies.iterator().next();
+    assertEquals(1, filteredDependency.getArtifacts().size());
+    assertEquals(externalArtifact, filteredDependency.getArtifacts().get(0).getUri());
+    assertEquals(2, dependency.getArtifacts().size());
+  }
+}


### PR DESCRIPTION
## Summary

- remove artifacts already represented as BSP build target dependencies from module dependencies
- preserve any remaining external artifacts on mixed dependency entries
- add regression coverage for cross-project Gradle configurations

## Root cause

After all source sets are collected, the build server correctly recognizes another project's output as a build target dependency. However, the same output remains in the source set's module dependencies and is returned by `buildTarget/dependencyModules`.

Consumers can therefore add both a workspace project entry and a binary library entry for the same dependency. Once the compiled output directory exists, JDT may resolve navigation against that binary entry and open decompiled source.

This change filters the duplicate artifact at the point where all workspace source sets and their outputs are known.

Fixes microsoft/vscode-gradle#1816.

## Validation

- `./gradlew :model:checkstyleMain :server:checkstyleTest :server:test --tests com.microsoft.java.bs.core.internal.gradle.GradleApiConnectorTest`
## Regression

This regression was introduced by #221 (`cbf7001`) on March 17, 2026. Its Gradle 9 compatibility change treated every non-module component artifact as a file dependency, which also exposed workspace project outputs through `buildTarget/dependencyModules`. The regression became user-visible in vscode-gradle 3.17.3, released on April 16, 2026.